### PR TITLE
docs(install): Add helm plugin manager install procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ $ helm diff [flags] RELEASE CHART
 
 
 ## Install
+
+### Using Helm plugin manager (> 2.3.x)
+
+```shell
+helm plugin install https://github.com/databus23/helm-diff/
+```
+
+### Pre Helm 2.3.0 Installation
 Pick a release tarball from the [releases](https://github.com/databus23/helm-diff/releases) page.
 
 Unpack the tarball in your helm plugins directory (`$(helm home)/plugins`).


### PR DESCRIPTION
Closes #2 

Using the plugin manager simplifies installation in Helm > 2.3.x