### PR TITLE
Enabling selecting filtering of diff output

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,10 +62,10 @@ func main() {
 
 	f := cmd.Flags()
 	f.BoolP("version", "v", false, "show version")
-	f.BoolP("suppress-secrets", "q", false,  "suppress secrets in the output")
+	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
 	f.StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
-	f.StringArrayVar(&diff.suppressedKinds, "suppress", []string{}, "suppress secrets in the output")
+	f.StringArrayVar(&diff.suppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -12,6 +12,12 @@ import (
 
 var yamlSeperator = []byte("\n---\n")
 
+type MappingResult struct {
+	Name string
+	Kind string
+	Content string
+}
+
 type metadata struct {
 	ApiVersion string `yaml:"apiVersion"`
 	Kind       string
@@ -47,7 +53,7 @@ func splitSpec(token string) (string, string) {
 	return "", ""
 }
 
-func Parse(manifest string) map[string]string {
+func Parse(manifest string) map[string]*MappingResult {
 	scanner := bufio.NewScanner(strings.NewReader(manifest))
 	scanner.Split(scanYamlSpecs)
 	//Allow for tokens (specs) up to 1M in size
@@ -55,7 +61,7 @@ func Parse(manifest string) map[string]string {
 	//Discard the first result, we only care about everything after the first seperator
 	scanner.Scan()
 
-	result := make(map[string]string)
+	result := make(map[string]*MappingResult)
 
 	for scanner.Scan() {
 		content := scanner.Text()
@@ -70,7 +76,11 @@ func Parse(manifest string) map[string]string {
 		if _, ok := result[name]; ok {
 			log.Println("Error: Found duplicate key %#v in manifest", name)
 		} else {
-			result[name] = content
+			result[name] = &MappingResult{
+				Name: name,
+				Kind: metadata.Kind,
+				Content: content,
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
Fixes #11 

- Allows easy suppression of secret content diff via the `-q` or `--suppress-secrets` flags 
- Allows additional customization of suppression via the `--suppress` flag