### PR TITLE
Support --reuse-values

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,9 @@ type diffCmd struct {
 	//	out     io.Writer
 	client helm.Interface
 	//	version int32
-	valueFiles valueFiles
-	values     []string
+	valueFiles  valueFiles
+	values      []string
+	reuseValues bool
 }
 
 func main() {
@@ -61,6 +62,7 @@ func main() {
 	f.BoolP("version", "v", false, "show version")
 	f.VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
 	f.StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.BoolVar(&diff.reuseValues, "reuse-values", false, "reuse the last release's values and merge in any new values")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
@@ -88,6 +90,7 @@ func (d *diffCmd) run() error {
 		d.release,
 		chartPath,
 		helm.UpdateValueOverrides(rawVals),
+		helm.ReuseValues(d.reuseValues),
 		helm.UpgradeDryRun(true),
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #13 

Love the plugin - it's been incredibly helpful for making upgrades smooth.  I think it would be very convenient to be able to replace `diff` with `upgrade` from a previous shell command and rerun it.  That is one less way for me to make mistakes during the process.  I'd imagine you don't want to start a trend of copying all the options for `helm upgrade` into this plugin.  This one seems pretty crucial to me, but let me know what you think!

FWIW, I was not able to test this on Helm 2.7.  I'm currently running 2.6, so I checked out `v2.5.0+1` (`HEAD~1` at time of writing) and branched off that to build and test.  I then `cherry-pick`ed that commit into this branch.  So all that said it'd be great if you can either a) test this on 2.7 yourself or b) give me a few weeks to upgrade my Tiller.  I share it with a handful of people so I can't do it immediately, but this change seems simple enough I expect it to work.