### PR TITLE
New chart diffing

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 )
 
 func main() {
-
 	if err := cmd.New().Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This provides the ability to do a `diff` on a release that does not currently exist.  This makes it much easier to use the plugin with things like `helmfile` as it doesn't error out and provides valuable feedback.  

NOTE: I have an additional PR that manages the merge conflicts of my two PRs that might be easier to merge for you. 