### PR TITLE
Ensure values files exist

### DIFF
--- a/helm.go
+++ b/helm.go
@@ -28,6 +28,22 @@ func (v *valueFiles) String() string {
 	return fmt.Sprint(*v)
 }
 
+// Ensures all valuesFiles exist
+func (v *valueFiles) Valid() error {
+	errStr := ""
+	for _, valuesFile := range *v {
+		if _, err := os.Stat(valuesFile); os.IsNotExist(err) {
+			errStr += err.Error()
+		}
+	}
+
+	if errStr == "" {
+		return nil
+	} else {
+		return errors.New(errStr)
+	}
+}
+
 func (v *valueFiles) Type() string {
 	return "valueFiles"
 }

--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func (d *diffCmd) run() error {
 		return err
 	}
 
+	if err := d.valueFiles.Valid(); err != nil {
+		return err
+	}
+
 	rawVals, err := d.vals()
 	if err != nil {
 		return err


### PR DESCRIPTION
Ensures that a value file actually exists instead of throwing up a golang exception when trying to open a file that doesn't exist