### PR TITLE
add namespace to deduplication tuple

### DIFF
--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -91,7 +91,12 @@ func (d *revision) differentiate() error {
 			return prettyError(err)
 		}
 
-		diff.DiffManifests(manifest.Parse(revisionResponse.Release.Manifest), manifest.Parse(releaseResponse.Release.Manifest), d.suppressedKinds, d.outputContext, os.Stdout)
+		diff.DiffManifests(
+			manifest.Parse(revisionResponse.Release.Manifest, revisionResponse.Release.Namespace),
+			manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace),
+			d.suppressedKinds,
+			d.outputContext,
+			os.Stdout)
 
 	case 2:
 		revision1, _ := strconv.Atoi(d.revisions[0])
@@ -110,7 +115,12 @@ func (d *revision) differentiate() error {
 			return prettyError(err)
 		}
 
-		diff.DiffManifests(manifest.Parse(revisionResponse1.Release.Manifest), manifest.Parse(revisionResponse2.Release.Manifest), d.suppressedKinds, d.outputContext, os.Stdout)
+		diff.DiffManifests(
+			manifest.Parse(revisionResponse1.Release.Manifest, revisionResponse1.Release.Namespace),
+			manifest.Parse(revisionResponse2.Release.Manifest, revisionResponse2.Release.Namespace),
+			d.suppressedKinds,
+			d.outputContext,
+			os.Stdout)
 
 	default:
 		return errors.New("Invalid Arguments")

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -82,7 +82,12 @@ func (d *rollback) backcast() error {
 	}
 
 	// create a diff between the current manifest and the version of the manifest that a user is intended to rollback
-	diff.DiffManifests(manifest.Parse(releaseResponse.Release.Manifest), manifest.Parse(revisionResponse.Release.Manifest), d.suppressedKinds, d.outputContext, os.Stdout)
+	diff.DiffManifests(
+		manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace),
+		manifest.Parse(revisionResponse.Release.Manifest, revisionResponse.Release.Namespace),
+		d.suppressedKinds,
+		d.outputContext,
+		os.Stdout)
 
 	return nil
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -121,7 +121,7 @@ func (d *diffCmd) run() error {
 		}
 
 		currentSpecs = make(map[string]*manifest.MappingResult)
-		newSpecs = manifest.Parse(installResponse.Release.Manifest)
+		newSpecs = manifest.Parse(installResponse.Release.Manifest, installResponse.Release.Namespace)
 	} else {
 		upgradeResponse, err := d.client.UpdateRelease(
 			d.release,
@@ -135,8 +135,8 @@ func (d *diffCmd) run() error {
 			return prettyError(err)
 		}
 
-		currentSpecs = manifest.Parse(releaseResponse.Release.Manifest)
-		newSpecs = manifest.Parse(upgradeResponse.Release.Manifest)
+		currentSpecs = manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace)
+		newSpecs = manifest.Parse(upgradeResponse.Release.Manifest, upgradeResponse.Release.Namespace)
 	}
 
 	diff.DiffManifests(currentSpecs, newSpecs, d.suppressedKinds, d.outputContext, os.Stdout)


### PR DESCRIPTION
helm charts can deploy to multiple namespaces at once, so compare on
(namespace, name, kind, version) instead of just (name, kind, version).

(We're deploying ResourceQuotas with the same name across multiple namespaces)