### PR TITLE
fix diff binary path in plugin.yaml

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,6 @@ version: "2.8.2+2"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true
-command: "$HELM_PLUGIN_DIR/bin/diff"
+command: "$HELM_PLUGIN_DIR/diff"
 hooks:
   install: "$HELM_PLUGIN_DIR/install-binary.sh"


### PR DESCRIPTION
Hi, 

The path specified in the plugin.yaml points to `~/.helm/plugins/helm-diff/bin/diff` while the binary is available at `~/.helm/plugins/helm-diff/diff`. This creates following error
```bash
$ helm diff -h
Error: fork/exec ~/.helm/plugins/helm-diff/bin/diff: no such file or directory
```