### PR TITLE
fix install-binary.sh version specification

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -67,7 +67,7 @@ verifySupported() {
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
   local url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
-  local version=$(git describe --tags --exact-match 2>/dev/null)
+  local version=$(git -C $HELM_PLUGIN_PATH describe --tags --exact-match 2>/dev/null)
   if [ -n "$version" ]; then
     url="https://api.github.com/repos/$PROJECT_GH/releases/tags/$version"
   fi


### PR DESCRIPTION
This fixes a bug where the --version flag that can be passed to `helm
plugin install` was not working with the install-binary.sh script that
this repository uses to install the binary files for users.

The issue was that the Helm runs install hooks in the current working
directory [1], so the `git describe` command that this repository was
executing was not being executed in the directory of the plugin, and
would thus always fail. The fix here is to use the `-C` flag to git to
specify the directory of the plugin source, ensuring that it will work
correctly regardless of the working directory from which the script is
executed.

Closes https://github.com/databus23/helm-diff/issues/50

[1] https://github.com/kubernetes/helm/blob/401f8bcc187d7a9edeec12c26c64819f105954d5/cmd/helm/plugin.go#L48-L72