### PR TITLE
Turn off debug for helm home

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,7 +5,7 @@
 PROJECT_NAME="helm-diff"
 PROJECT_GH="databus23/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-diff"}
+: ${HELM_PLUGIN_PATH:="$(helm home --debug=false)/plugins/helm-diff"}
 
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,4 +8,3 @@ useTunnel: true
 command: "$HELM_PLUGIN_DIR/bin/diff"
 hooks:
   install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,4 +8,4 @@ useTunnel: true
 command: "$HELM_PLUGIN_DIR/bin/diff"
 hooks:
   install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"helm
+  update: "$HELM_PLUGIN_DIR/install-binary.sh"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,3 +8,4 @@ useTunnel: true
 command: "$HELM_PLUGIN_DIR/bin/diff"
 hooks:
   install: "$HELM_PLUGIN_DIR/install-binary.sh"
+  update: "$HELM_PLUGIN_DIR/install-binary.sh"


### PR DESCRIPTION
When installing plugin in debug mode helm home is also running in debug mode and returning wrong values.

This patch adds --debug=false flag to helm home