### PR TITLE
feat: Capability to diff changes in chart hooks

### DIFF
--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -92,8 +92,8 @@ func (d *revision) differentiate() error {
 		}
 
 		diff.DiffManifests(
-			manifest.Parse(revisionResponse.Release.Manifest, revisionResponse.Release.Namespace),
-			manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace),
+			manifest.ParseRelease(revisionResponse.Release),
+			manifest.ParseRelease(releaseResponse.Release),
 			d.suppressedKinds,
 			d.outputContext,
 			os.Stdout)
@@ -116,8 +116,8 @@ func (d *revision) differentiate() error {
 		}
 
 		diff.DiffManifests(
-			manifest.Parse(revisionResponse1.Release.Manifest, revisionResponse1.Release.Namespace),
-			manifest.Parse(revisionResponse2.Release.Manifest, revisionResponse2.Release.Namespace),
+			manifest.ParseRelease(revisionResponse1.Release),
+			manifest.ParseRelease(revisionResponse2.Release),
 			d.suppressedKinds,
 			d.outputContext,
 			os.Stdout)

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -83,8 +83,8 @@ func (d *rollback) backcast() error {
 
 	// create a diff between the current manifest and the version of the manifest that a user is intended to rollback
 	diff.DiffManifests(
-		manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace),
-		manifest.Parse(revisionResponse.Release.Manifest, revisionResponse.Release.Namespace),
+		manifest.ParseRelease(releaseResponse.Release),
+		manifest.ParseRelease(revisionResponse.Release),
 		d.suppressedKinds,
 		d.outputContext,
 		os.Stdout)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -135,8 +135,8 @@ func (d *diffCmd) run() error {
 			return prettyError(err)
 		}
 
-		currentSpecs = manifest.Parse(releaseResponse.Release.Manifest, releaseResponse.Release.Namespace)
-		newSpecs = manifest.Parse(upgradeResponse.Release.Manifest, upgradeResponse.Release.Namespace)
+		currentSpecs = manifest.ParseRelease(releaseResponse.Release)
+		newSpecs = manifest.ParseRelease(upgradeResponse.Release)
 	}
 
 	diff.DiffManifests(currentSpecs, newSpecs, d.suppressedKinds, d.outputContext, os.Stdout)

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 var yamlSeperator = []byte("\n---\n")
@@ -52,6 +53,16 @@ func splitSpec(token string) (string, string) {
 		return token[0:i], token[i+1:]
 	}
 	return "", ""
+}
+
+func ParseRelease(release *release.Release) map[string]*MappingResult {
+	manifest := release.Manifest
+	for _, hook := range release.Hooks {
+		manifest += "\n---\n"
+		manifest += fmt.Sprintf("# Source: %s\n", hook.Path)
+		manifest += hook.Manifest
+	}
+	return Parse(manifest, release.Namespace)
 }
 
 func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {


### PR DESCRIPTION
Currently helm diff does not parse helm hooks. This appends hooks to the manifest diffs so that it can include them to be diff. Added capability to revision,upgrade and rollback. 