### PR TITLE
feat: Dedicated exit code (2) on there's diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ LDFLAGS := -X $(PKG)/cmd.Version=$(VERSION)
 LDFLAGS += -X $(PKG)/vendor/k8s.io/helm/pkg/version.BuildMetadata=
 LDFLAGS += -X $(PKG)/vendor/k8s.io/helm/pkg/version.Version=$(shell grep -A1 "package: k8s.io/helm" glide.yaml | sed -n -e 's/[ ]*version:.*\(v[.0-9]*\).*/\1/p')
 
+.PHONY: format
+format:
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
+
 .PHONY: install
 install: build
 	mkdir -p $(HELM_HOME)/plugins/helm-diff/bin

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -1,0 +1,6 @@
+package cmd
+
+type Error struct {
+	error
+	Code int
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,26 +5,26 @@ import (
 	"os"
 	"strings"
 
+	"errors"
 	"github.com/databus23/helm-diff/diff"
 	"github.com/databus23/helm-diff/manifest"
 	"github.com/spf13/cobra"
 	"k8s.io/helm/pkg/helm"
-	"errors"
 )
 
 type diffCmd struct {
-	release           string
-	chart             string
-	chartVersion      string
-	client            helm.Interface
-	detailedExitCode 	bool
-	valueFiles        valueFiles
-	values            []string
-	reuseValues       bool
-	resetValues       bool
-	allowUnreleased   bool
-	suppressedKinds   []string
-	outputContext     int
+	release          string
+	chart            string
+	chartVersion     string
+	client           helm.Interface
+	detailedExitCode bool
+	valueFiles       valueFiles
+	values           []string
+	reuseValues      bool
+	resetValues      bool
+	allowUnreleased  bool
+	suppressedKinds  []string
+	outputContext    int
 }
 
 const globalUsage = `Show a diff explaining what a helm upgrade would change.
@@ -150,7 +150,10 @@ func (d *diffCmd) run() error {
 	seenAnyChanges := diff.DiffManifests(currentSpecs, newSpecs, d.suppressedKinds, d.outputContext, os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {
-		return errors.New("identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)")
+		return Error{
+			error: errors.New("identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)"),
+			Code:  2,
+		}
 	}
 
 	return nil

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -3,8 +3,8 @@ package diff
 import (
 	"fmt"
 	"io"
-	"strings"
 	"math"
+	"strings"
 
 	"github.com/aryann/difflib"
 	"github.com/mgutz/ansi"

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/databus23/helm-diff/cmd"
 )
@@ -10,6 +10,11 @@ import (
 func main() {
 	if err := cmd.New().Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		switch e := err.(type) {
+		case cmd.Error:
+			os.Exit(e.Code)
+		default:
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
This feature is enabled only when the `--detailed-exitcode` flag (#65) is provided.
Supports `upgrade`, `revision` and `rollback` sub-commands.

Resolves #54, but only after https://github.com/helm/helm/pull/4367 is released with helm v2.11.0, probably.