### PR TITLE
add --set-string flag to ensure proper parsing of strings

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -163,6 +163,13 @@ func (d *diffCmd) vals() ([]byte, error) {
 		}
 	}
 
+	// User specified a value via --set-string
+	for _, value := range d.stringValues {
+		if err := strvals.ParseIntoString(value, base); err != nil {
+			return []byte{}, fmt.Errorf("failed parsing --set-string data: %s", err)
+		}
+	}
+
 	return yaml.Marshal(base)
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -20,6 +20,7 @@ type diffCmd struct {
 	detailedExitCode bool
 	valueFiles       valueFiles
 	values           []string
+	stringValues     []string
 	reuseValues      bool
 	resetValues      bool
 	allowUnreleased  bool
@@ -72,6 +73,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
 	f.StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.StringArrayVar(&diff.stringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.BoolVar(&diff.reuseValues, "reuse-values", false, "reuse the last release's values and merge in any new values")
 	f.BoolVar(&diff.resetValues, "reset-values", false, "reset the values to the ones built into the chart and merge in any new values")
 	f.BoolVar(&diff.allowUnreleased, "allow-unreleased", false, "enables diffing of releases that are not yet deployed via Helm")


### PR DESCRIPTION
This resolves an issue where numeric values intended to be
used as strings could be interpreted as float64 values,
causing varius things to fail in unexpected ways.

This fix mirrors the changes in the following PR to Helm
itself: https://github.com/helm/helm/pull/3599

Closes https://github.com/databus23/helm-diff/issues/83