### PR TITLE
Fix: Bumping helm dep to v2.11.0

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -5,9 +5,7 @@ import:
 - package: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - package: k8s.io/helm
-  #revert back to upstream once https://github.com/helm/helm/pull/4499 is released
-  repo: https://github.com/databus23/helm.git
-  version: v2.10.0-nok8s
+  version: v2.11.0
 #taken from k8s.io/helm glide.yaml
 - package: k8s.io/api
   version: release-1.10


### PR DESCRIPTION
## Description
Client version within `helm-diff` was coming up empty while running [helmsman](https://github.com/Praqma/helmsman). `helmsman` requires this plugin as a dependency for its newer versions.

The LDFLAG build metadata for parsing the helm package inside
glide.yaml has to have the next line be "version". It parses
"version" to validate the helm version used to build helm-diff.

Ended up bumping to helm v2.11.0 since that was released 2 weeks
ago and the previous comment mentioned removing it once PR #4499
was released in helm.

## Previous Behavior
While using `helm-diff` with `helmsman`:
```
$ helmsman -debug -f helmsman.yaml
2018/10/10 23:19:27 INFO: checking what I need to do for your charts ...
2018/10/10 23:19:27 INFO: mapping the current helm state ...
2018/10/10 23:19:27 INFO: listing all existing releases in namespace [ kube-system ]...
2018/10/10 23:19:27 INFO: upgrading release [ nginx ] using Tiller in [ kube-system ]
2018/10/10 23:19:28 Command returned with exit code: . And error message: Error:
incompatible versions client[] server[v2.10.0] Error: plugin "diff" exited with error
```

`client[]` is empty which should not be the case since it is incompatible with tiller version.

## New Behavior
With this `patch` I was able to:
```
$ gmake bootstrap
...
$ gmake build
...
$ bin/diff version
2.10.0+2                         

$ helmsman -debug -f helmsman.yaml
2018/10/11 01:35:04 INFO: checking if any Helmsman managed releases are no longer tracked by your desired state ...
2018/10/11 01:35:04 INFO: getting helm releases which are managed by Helmsman in namespace [[ kube-system ]].
2018/10/11 01:35:05 INFO: getting helm releases which are managed by Helmsman in namespace [[ kube-system ]].
2018/10/11 01:35:05 INFO: no untracked releases found.
2018/10/11 01:35:05 INFO: sorting the commands in the plan based on priorities (order
flags) ...
----------------------
```

Its now working as expected once I upgraded `tiller` to `v2.11.0` as well!

## Config

```
$ uname -sr
FreeBSD 11.2-RELEASE-p1
$ glide --version
glide version 0.13.0-dev
$ helm version
Client: &version.Version{SemVer:"v2.11.0+unreleased", GitCommit:"", GitTreeState:""}
Server: &version.Version{SemVer:"v2.11.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
$ helmsman -h
 _          _
| |        | | 
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \ 
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | | 
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_|

Helmsman version: v1.6.2
```