### PR TITLE
Feat: build freebsd bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ dist:
 	cp README.md LICENSE plugin.yaml build/diff
 	GOOS=linux GOARCH=amd64 go build -o build/diff/bin/diff -ldflags="$(LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-diff-linux.tgz diff/
+	GOOS=freebsd GOARCH=amd64 go build -o build/diff/bin/diff -ldflags="$(LDFLAGS)"
+	tar -C build/ -zcvf $(CURDIR)/release/helm-diff-freebsd.tgz diff/
 	GOOS=darwin GOARCH=amd64 go build -o build/diff/bin/diff -ldflags="$(LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-diff-macos.tgz diff/
 	rm build/diff/bin/diff

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Shamelessly copied from https://github.com/technosophos/helm-template
 
@@ -52,7 +52,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-amd64\nmacos-amd64\nwindows-amd64"
+  local supported="linux-amd64\nfreebsd-amd64\nmacos-amd64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1


### PR DESCRIPTION
## Description
Enable `helm-diff` on `freebsd`

## Previous Behavior
* No freebsd binary for releases
* Could not install plugin using `helm plugin install https://github.com/databus23/helm-diff --version master`

## New Behavior
* Build freebsd binary for releases
* Should be able to use `helm plugin install https://github.com/databus23/helm-diff --version master` (will have to test once release of new version actually happens)

It currently works fine if built locally:

```
$ gmake build
mkdir -p bin/
go build -i -v -o bin/diff -ldflags="-X github.com/databus23/helm-diff/cmd.Version=2.10.0+2 -X github.com/databus23/helm-diff/vendor/k8s.io/helm/pkg/version.BuildMetadata= -X github.com/databus23/helm-diff/vendor/k8s.io/helm/pkg/version.Version="
$ bin/diff version
2.10.0+2
$ gmake dist
...
GOOS=freebsd GOARCH=amd64 go build -o build/diff/bin/diff -ldflags="-X github.com/databus23/helm-diff/cmd.Version=2.10.0+2 -X github.com/databus23/helm-diff/vendor/k8s.io/helm/pkg/version.BuildMetadata= -X github.com/databus23/helm-diff/vendor/k8s.io/helm/pkg/version.Version="
tar -C build/ -zcvf /usr/home/rherna/.helm/cache/plugins/https-github.com-databus23-helm-diff/release/helm-diff-freebsd.tgz diff/
a diff
a diff/LICENSE
a diff/README.md
a diff/plugin.yaml
a diff/bin
a diff/bin/diff
...
$ cd release/
$ tar zxvf helm-diff-freebsd.tgz
x diff/
x diff/LICENSE
x diff/README.md
x diff/plugin.yaml                                                                                                                                                                                                                     
x diff/bin/
 diff/bin/diff
$ diff/bin/diff version
2.10.0+2 
```

## Config

```
$ uname -srm
FreeBSD 11.2-RELEASE-p1 amd64
$ glide --version
glide version 0.13.0-dev
$ helm version
Client: &version.Version{SemVer:"v2.11.0+unreleased", GitCommit:"", GitTreeState:""}
Server: &version.Version{SemVer:"v2.11.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
```