### PR TITLE
Use AddFlagsTLS from helm to add tls cmd options.

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -34,7 +34,13 @@ func createHelmClient() helm.Interface {
 	options := []helm.Option{helm.Host(os.Getenv("TILLER_HOST")), helm.ConnectTimeout(int64(30))}
 
 	if settings.TLSVerify || settings.TLSEnable {
-		tlsopts := tlsutil.Options{KeyFile: settings.TLSKeyFile, CertFile: settings.TLSCertFile, InsecureSkipVerify: true}
+		tlsopts := tlsutil.Options{
+			ServerName:         settings.TLSServerName,
+			KeyFile:            settings.TLSKeyFile,
+			CertFile:           settings.TLSCertFile,
+			InsecureSkipVerify: true,
+		}
+
 		if settings.TLSVerify {
 			tlsopts.CaCertFile = settings.TLSCaCertFile
 			tlsopts.InsecureSkipVerify = false


### PR DESCRIPTION
To enable support for the TLS environment variables (HELM_TLS_ENABLE), I replace the old tls parse logic with the AddFlagsTLS method from Helm.