### PR TITLE
Bump helm to 2.12.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,14 @@
-hash: 41869ddd7c45fba60173a6fcf13ef7aa202e3f2581dfebed02e4f9fd57a364be
-updated: 2018-10-11T10:43:24.76598+02:00
+hash: 32f41204d159361588c8d1a2800770a3250af68d12a6f1748e06b94b0557e9b4
+updated: 2018-12-20T23:25:22.185044+01:00
 imports:
 - name: github.com/aokoli/goutils
-  version: 3391d3790d23d03408670993e957e8f408993c34
+  version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/aryann/difflib
-  version: a1a4dd44eb11820695fbe83e00fb2301ee6eb54c
+  version: e206f873d14a916d3d26c40ab667bca123f365a3
 - name: github.com/BurntSushi/toml
   version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: c7ce16629ff4cd059ed96ed06419dd3856fd3577
 - name: github.com/gobwas/glob
   version: 5ccd90ef52e1e632236f7326478d4faa74f99438
   subpackages:
@@ -20,7 +20,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
   - ptypes
@@ -32,7 +32,7 @@ imports:
 - name: github.com/huandu/xstrings
   version: 8bbcf2f9ccb55755e748b7644164cd4bdce94c1d
 - name: github.com/imdario/mergo
-  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/Masterminds/semver
@@ -40,9 +40,9 @@ imports:
 - name: github.com/Masterminds/sprig
   version: 15f9564e7e9cf0da02a48e0d25f12a7b83559aa6
 - name: github.com/mattn/go-colorable
-  version: ded68f7a9561c023e790de24279db7ebf473ea80
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 3fb116b820352b7f0c281308a4d6250c22d94e27
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
 - name: github.com/spf13/cobra
@@ -50,7 +50,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
   - cast5
   - openpgp
@@ -64,7 +64,7 @@ imports:
   - scrypt
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - context
   - http2
@@ -86,7 +86,7 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  version: 5a97ab628bfb2f65f6befec18f4bc7bc7f382b77
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -110,19 +110,67 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: 670d4cfef0544295bc27a114dbac37980d83185a
-- name: k8s.io/api
-  version: 2d6f90ab1293a1fb871cf149423ebb72aa7423aa
+  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
 - name: k8s.io/apimachinery
-  version: 103fd098999dc9c0c88536f5c9ad2e5da39373ae
+  version: 98853ca904e81a25e2000cae7f077dc30f81b85f
   subpackages:
+  - pkg/api/apitesting
+  - pkg/api/apitesting/fuzzer
+  - pkg/api/apitesting/roundtrip
+  - pkg/api/equality
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apis/meta/fuzzer
+  - pkg/apis/meta/internalversion
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1beta1
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/types
+  - pkg/util/cache
+  - pkg/util/clock
+  - pkg/util/diff
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/httpstream
+  - pkg/util/httpstream/spdy
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/mergepatch
+  - pkg/util/naming
+  - pkg/util/net
+  - pkg/util/remotecommand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/strategicpatch
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
   - pkg/version
+  - pkg/watch
+  - third_party/forked/golang/json
+  - third_party/forked/golang/netutil
+  - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 23781f4d6632d88e869066eaebb743857aa1ef9b
+  version: 150ac40a918a222bb519486e823d07c96a59f3ff
   subpackages:
   - util/homedir
 - name: k8s.io/helm
-  version: 2e55dbe1fdb5fdb96b75ff144a339489417b146b
+  version: 02a47c7249b1fc6d8fd3b94e6b4babf9d818144e
   subpackages:
   - pkg/chartutil
   - pkg/downloader

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,20 +1,7 @@
 package: github.com/databus23/helm-diff
 import:
-- package: github.com/spf13/cobra
-  version: 615425954c3b0d9485a7027d4d451fdcdfdee84e
-- package: github.com/spf13/pflag
-  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - package: k8s.io/helm
-  version: v2.11.0
-#taken from k8s.io/helm glide.yaml
-- package: k8s.io/api
-  version: kubernetes-1.11.1 
-- package: k8s.io/apimachinery
-  version: kubernetes-1.11.1
-- package: google.golang.org/grpc
-  version: 1.7.2
-- package: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: v2.12.1
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.2.2


### PR DESCRIPTION
See https://github.com/databus23/helm-diff/issues/112

I also remove dependencies which already defined in helms glide.yaml

```
root@4266d5eab234:/go/src/github.com/databus23/helm-diff# make test
go test -v ./...
?       github.com/databus23/helm-diff  [no test files]
?       github.com/databus23/helm-diff/cmd      [no test files]
=== RUN   TestPrintDiffWithContext
=== RUN   TestPrintDiffWithContext/context-disabled
=== RUN   TestPrintDiffWithContext/context-0
=== RUN   TestPrintDiffWithContext/context-1
=== RUN   TestPrintDiffWithContext/context-2
=== RUN   TestPrintDiffWithContext/context-3
--- PASS: TestPrintDiffWithContext (0.00s)
    --- PASS: TestPrintDiffWithContext/context-disabled (0.00s)
    --- PASS: TestPrintDiffWithContext/context-0 (0.00s)
    --- PASS: TestPrintDiffWithContext/context-1 (0.00s)
    --- PASS: TestPrintDiffWithContext/context-2 (0.00s)
    --- PASS: TestPrintDiffWithContext/context-3 (0.00s)
=== RUN   TestDiffManifests
=== RUN   TestDiffManifests/OnChange
=== RUN   TestDiffManifests/OnNoChange
--- PASS: TestDiffManifests (0.00s)
    --- PASS: TestDiffManifests/OnChange (0.00s)
    --- PASS: TestDiffManifests/OnNoChange (0.00s)
PASS
ok      github.com/databus23/helm-diff/diff     0.007s
=== RUN   TestPod
--- PASS: TestPod (0.01s)
=== RUN   TestPodNamespace
--- PASS: TestPodNamespace (0.00s)
=== RUN   TestDeployV1
--- PASS: TestDeployV1 (0.00s)
=== RUN   TestDeployV1Beta1
--- PASS: TestDeployV1Beta1 (0.00s)
PASS
ok      github.com/databus23/helm-diff/manifest 0.023s
```

```
# go version
go version go1.11.2 linux/amd64
```
