### PR TITLE
Skip yaml blocks without any metadata

### DIFF
--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -58,3 +58,13 @@ func TestDeployV1Beta1(t *testing.T) {
 		foundObjects(Parse(string(spec), "default")),
 	)
 }
+
+func TestEmpty(t *testing.T) {
+	spec, err := ioutil.ReadFile("testdata/empty.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{},
+		foundObjects(Parse(string(spec), "default")),
+	)
+}

--- a/manifest/testdata/empty.yaml
+++ b/manifest/testdata/empty.yaml
@@ -1,0 +1,8 @@
+---
+# Source: nginx/pod.yaml
+# This template is empty
+# and only contains comments
+---
+# Source: nginx/pod.yaml
+# This template is empty
+# and only contains comments


### PR DESCRIPTION
Fixes the variant of #48 reported by bfin, jcalahan and adidenko.

If you have templates that wind up containing only comments, they should be skipped.  This change checks to see if the metadata is completely empty to detect effectively blank yaml content.

To do this without an extraneous comparison variable, I had to unshadow the metadata type.  This resulted in a few extra cosmetic changes in the diff.