### PR TITLE
Fix install when HELM_PATH contains a space

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -118,7 +118,7 @@ fail_trap() {
 testVersion() {
   set +e
   echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH/$PROJECT_NAME"
-  $HELM_PLUGIN_PATH/bin/diff -h
+  "${HELM_PLUGIN_PATH}/bin/diff" -h
   set -e
 }
 


### PR DESCRIPTION
```
gabdav01@e109198-mac:~/tmp
export HELM_HOME="/tmp/foo me"

gabdav01@e109198-mac:~/tmp
$ helm init --client-only
Creating /tmp/foo me
Creating /tmp/foo me/repository
Creating /tmp/foo me/repository/cache
Creating /tmp/foo me/repository/local
Creating /tmp/foo me/plugins
Creating /tmp/foo me/starters
Creating /tmp/foo me/cache/archive
Creating /tmp/foo me/repository/repositories.yaml
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
Adding local repo with URL: http://127.0.0.1:8879/charts
$HELM_HOME has been configured at /tmp/foo me.
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!

gabdav01@e109198-mac:~/tmp
$ helm plugin install https://github.com/databus23/helm-diff
sh: /tmp/foo: No such file or directory
Error: plugin install hook for "diff" exited with error

gabdav01@e109198-mac:~/tmp
```
