### PR TITLE
Fix: Check for errors after scanner.Scan()

### DIFF
--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -115,6 +115,9 @@ func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {
 			}
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading input: %s", err)
+	}
 	return result
 }
 


### PR DESCRIPTION
The scanner has a fixed buffer size of 1MB. If this is exceeded scanning will fail silently, leading to misleading diff output.

This helps improve the failure mode for #139.