### PR TITLE
support helm 3 using exec

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func getRelease(release, namespace string) ([]byte, error) {
+	args := []string{"get", "manifest", release}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return cmd.Output()
+}
+
+func getHooks(release, namespace string) ([]byte, error) {
+	args := []string{"get", "hooks", release}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return cmd.Output()
+}
+
+func getRevision(release string, revision int, namespace string) ([]byte, error) {
+	args := []string{"get", "manifest", release, "--revision", strconv.Itoa(revision)}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return cmd.Output()
+}
+
+func getChart(release, namespace string) (string, error) {
+	args := []string{"get", release, "--template", "{{.Release.Chart.Name}}"}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func (d *diffCmd) template() ([]byte, error) {
+	flags := []string{}
+	if d.devel {
+		flags = append(flags, "--devel")
+	}
+	if d.noHooks {
+		flags = append(flags, "--no-hooks")
+	}
+	if d.chartVersion != "" {
+		flags = append(flags, "--version", d.chartVersion)
+	}
+	if d.namespace != "" {
+		flags = append(flags, "--namespace", d.namespace)
+	}
+	if !d.resetValues {
+		if d.reuseValues {
+			tmpfile, err := ioutil.TempFile("", "existing-values")
+			if err != nil {
+				return nil, err
+			}
+			defer os.Remove(tmpfile.Name())
+			flags = append(flags, "--values", tmpfile.Name())
+		}
+		for _, value := range d.values {
+			flags = append(flags, "--set", value)
+		}
+		for _, stringValue := range d.stringValues {
+			flags = append(flags, "--set-string", stringValue)
+		}
+		for _, valueFile := range d.valueFiles {
+			flags = append(flags, "--values", valueFile)
+		}
+		for _, fileValue := range d.fileValues {
+			flags = append(flags, "--set-file", fileValue)
+		}
+	}
+
+	args := []string{"template", d.release, d.chart}
+	args = append(args, flags...)
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return cmd.Output()
+}
+
+func (d *diffCmd) existingValues(f *os.File) error {
+	cmd := exec.Command(os.Getenv("HELM_BIN"), "get", "values", d.release, "--all")
+	defer f.Close()
+	cmd.Stdout = f
+	return cmd.Run()
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -24,6 +24,10 @@ var (
 	DefaultHelmHome = filepath.Join(homedir.HomeDir(), ".helm")
 )
 
+func isHelm3() bool {
+	return os.Getenv("TILLER_HOST") == ""
+}
+
 func addCommonCmdOptions(f *flag.FlagSet) {
 	settings.AddFlagsTLS(f)
 	settings.InitTLS(f)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -16,6 +16,9 @@ const (
 	tlsCaCertDefault = "$HELM_HOME/ca.pem"
 	tlsCertDefault   = "$HELM_HOME/cert.pem"
 	tlsKeyDefault    = "$HELM_HOME/key.pem"
+
+	helm2TestSuccessHook = "test-success"
+	helm3TestHook        = "test"
 )
 
 var (

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -70,6 +70,9 @@ func revisionCmd() *cobra.Command {
 
 			diff.release = args[0]
 			diff.revisions = args[1:]
+			if isHelm3() {
+				return diff.differentiateHelm3()
+			}
 			if diff.client == nil {
 				diff.client = createHelmClient()
 			}
@@ -80,12 +83,76 @@ func revisionCmd() *cobra.Command {
 	revisionCmd.Flags().BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	revisionCmd.Flags().StringArrayVar(&diff.suppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
 	revisionCmd.Flags().IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
-	revisionCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
+	if !isHelm3() {
+		revisionCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
+	}
 	revisionCmd.SuggestionsMinimumDistance = 1
 
-	addCommonCmdOptions(revisionCmd.Flags())
+	if !isHelm3() {
+		addCommonCmdOptions(revisionCmd.Flags())
+	}
 
 	return revisionCmd
+}
+
+func (d *revision) differentiateHelm3() error {
+	switch len(d.revisions) {
+	case 1:
+		releaseResponse, err := getRelease(d.release, "")
+
+		if err != nil {
+			return err
+		}
+
+		revision, _ := strconv.Atoi(d.revisions[0])
+		revisionResponse, err := getRevision(d.release, revision, "")
+		if err != nil {
+			return err
+		}
+
+		diff.Manifests(
+			manifest.Parse(string(revisionResponse), ""),
+			manifest.Parse(string(releaseResponse), ""),
+			d.suppressedKinds,
+			d.outputContext,
+			os.Stdout)
+
+	case 2:
+		revision1, _ := strconv.Atoi(d.revisions[0])
+		revision2, _ := strconv.Atoi(d.revisions[1])
+		if revision1 > revision2 {
+			revision1, revision2 = revision2, revision1
+		}
+
+		revisionResponse1, err := getRevision(d.release, revision1, "")
+		if err != nil {
+			return prettyError(err)
+		}
+
+		revisionResponse2, err := getRevision(d.release, revision2, "")
+		if err != nil {
+			return prettyError(err)
+		}
+
+		seenAnyChanges := diff.Manifests(
+			manifest.Parse(string(revisionResponse1), ""),
+			manifest.Parse(string(revisionResponse2), ""),
+			d.suppressedKinds,
+			d.outputContext,
+			os.Stdout)
+
+		if d.detailedExitCode && seenAnyChanges {
+			return Error{
+				error: errors.New("identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)"),
+				Code:  2,
+			}
+		}
+
+	default:
+		return errors.New("Invalid Arguments")
+	}
+
+	return nil
 }
 
 func (d *revision) differentiate() error {

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -89,8 +89,8 @@ func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {
 	result := make(map[string]*MappingResult)
 
 	for scanner.Scan() {
-		content := scanner.Text()
-		if strings.TrimSpace(content) == "" {
+		content := strings.TrimSpace(scanner.Text())
+		if content == "" {
 			continue
 		}
 		var parsedMetadata metadata

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -11,6 +11,10 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
+const (
+	hookAnnotation = "helm.sh/hook"
+)
+
 var yamlSeperator = []byte("\n---\n")
 
 // MappingResult to store result of diff
@@ -24,8 +28,9 @@ type metadata struct {
 	APIVersion string `yaml:"apiVersion"`
 	Kind       string
 	Metadata   struct {
-		Namespace string
-		Name      string
+		Namespace   string
+		Name        string
+		Annotations map[string]string
 	}
 }
 
@@ -78,7 +83,7 @@ func ParseRelease(release *release.Release, includeTests bool) map[string]*Mappi
 }
 
 // Parse parses manifest strings into MappingResult
-func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {
+func Parse(manifest string, defaultNamespace string, excludedHooks ...string) map[string]*MappingResult {
 	scanner := bufio.NewScanner(strings.NewReader(manifest))
 	scanner.Split(scanYamlSpecs)
 	//Allow for tokens (specs) up to 1M in size
@@ -100,7 +105,10 @@ func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {
 
 		//Skip content without any metadata.  It is probably a template that
 		//only contains comments in the current state.
-		if (metadata{}) == parsedMetadata {
+		if parsedMetadata.APIVersion == "" && parsedMetadata.Kind == "" {
+			continue
+		}
+		if isHook(parsedMetadata, excludedHooks...) {
 			continue
 		}
 
@@ -122,6 +130,15 @@ func Parse(manifest string, defaultNamespace string) map[string]*MappingResult {
 		log.Fatalf("Error reading input: %s", err)
 	}
 	return result
+}
+
+func isHook(metadata metadata, hooks ...string) bool {
+	for _, hook := range hooks {
+		if metadata.Metadata.Annotations[hookAnnotation] == hook {
+			return true
+		}
+	}
+	return false
 }
 
 func isTestHook(hookEvents []release.Hook_Event) bool {

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -39,6 +39,26 @@ func TestPodNamespace(t *testing.T) {
 	)
 }
 
+func TestPodHook(t *testing.T) {
+	spec, err := ioutil.ReadFile("testdata/pod_hook.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{"default, nginx, Pod (v1)"},
+		foundObjects(Parse(string(spec), "default")),
+	)
+
+	require.Equal(t,
+		[]string{"default, nginx, Pod (v1)"},
+		foundObjects(Parse(string(spec), "default", "test-success")),
+	)
+
+	require.Equal(t,
+		[]string{},
+		foundObjects(Parse(string(spec), "default", "test")),
+	)
+}
+
 func TestDeployV1(t *testing.T) {
 	spec, err := ioutil.ReadFile("testdata/deploy_v1.yaml")
 	require.NoError(t, err)

--- a/manifest/testdata/pod_hook.yaml
+++ b/manifest/testdata/pod_hook.yaml
@@ -1,0 +1,15 @@
+
+---
+# Source: nginx/pod.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  annotations:
+    helm.sh/hook: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.7.9
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
Here is an other version for #147 which shells out to `HELM_BIN`.

The following helm commands are used:
- `helm template` for update
- `helm get` to retrieve releases and revisions

The following flags are not supported in helm 3 mode:
- `--set-file` in `upgrade`
- `--no-hooks` in `upgrade` (`helm template` in v3.0.0-beta.3 ignores this flag and returns always no hooks)
- `--include-tests` in all commands as we ignore all hooks

It would be possible to get the hooks for the installed releases/revisions if it is really needed.