### PR TITLE
fix / simplify install script

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,136 +1,37 @@
-#!/usr/bin/env bash
+#!/bin/sh -e
 
-# Shamelessly copied from https://github.com/technosophos/helm-template
-
-PROJECT_NAME="helm-diff"
-PROJECT_GH="databus23/$PROJECT_NAME"
-
-: ${HELM_PLUGIN_PATH:="$(helm home --debug=false)/plugins/helm-diff"}
-
-# Convert the HELM_PLUGIN_PATH to unix if cygpath is
-# available. This is the case when using MSYS2 or Cygwin
-# on Windows where helm returns a Windows path but we
-# need a Unix path
-
-if type cygpath > /dev/null 2>&1; then
-  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
+if [ -n "${HELM_LINTER_PLUGIN_NO_INSTALL_HOOK}" ]; then
+    echo "Development mode: not downloading versioned release."
+    exit 0
 fi
 
-if [[ $SKIP_BIN_INSTALL == "1" ]]; then
-  echo "Skipping binary install"
-  exit
+# shellcheck disable=SC2002
+version="$(cat plugin.yaml | grep "version:" | cut -d '"' -f 2)"
+echo "Downloading and installing helm-diff v${version} ..."
+
+url=""
+if [ "$(uname)" = "Darwin" ]; then
+    url="https://github.com/databus23/helm-diff/releases/download/v${version}/helm-diff-macos.tgz"
+elif [ "$(uname)" = "Linux" ] ; then
+    url="https://github.com/databus23/helm-diff/releases/download/v${version}/helm-diff-linux.tgz"
+else
+    url="https://github.com/databus23/helm-diff/releases/download/v${version}/helm-diff-windows.tgz"
 fi
 
-# initArch discovers the architecture for this system.
-initArch() {
-  ARCH=$(uname -m)
-  case $ARCH in
-    armv5*) ARCH="armv5";;
-    armv6*) ARCH="armv6";;
-    armv7*) ARCH="armv7";;
-    aarch64) ARCH="arm64";;
-    x86) ARCH="386";;
-    x86_64) ARCH="amd64";;
-    i686) ARCH="386";;
-    i386) ARCH="386";;
-  esac
-}
+echo "$url"
 
-# initOS discovers the operating system for this system.
-initOS() {
-  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+mkdir -p "bin"
+mkdir -p "releases/v${version}"
 
-  case "$OS" in
-    # Msys support
-    msys*) OS='windows';;
-    # Minimalist GNU for Windows
-    mingw*) OS='windows';;
-    darwin) OS='macos';;
-  esac
-}
+# Download with curl if possible.
+# shellcheck disable=SC2230
+if [ -x "$(which curl 2>/dev/null)" ]; then
+    curl -sSL "${url}" -o "releases/v${version}.tar.gz"
+else
+    wget -q "${url}" -O "releases/v${version}.tar.gz"
+fi
 
-# verifySupported checks that the os/arch combination is supported for
-# binary builds.
-verifySupported() {
-  local supported="linux-amd64\nfreebsd-amd64\nmacos-amd64\nwindows-amd64"
-  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
-    echo "No prebuild binary for ${OS}-${ARCH}."
-    exit 1
-  fi
 
-  if ! type "curl" > /dev/null && ! type "wget" > /dev/null; then
-    echo "Either curl or wget is required"
-    exit 1
-  fi
-}
-
-# getDownloadURL checks the latest available version.
-getDownloadURL() {
-  local version=$(git -C $HELM_PLUGIN_PATH describe --tags --exact-match 2>/dev/null)
-  if [ -n "$version" ]; then
-    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/helm-diff-$OS.tgz"
-  else
-    # Use the GitHub API to find the download url for this project.
-    local url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
-    if type "curl" > /dev/null; then
-      DOWNLOAD_URL=$(curl -s $url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-    elif type "wget" > /dev/null; then
-      DOWNLOAD_URL=$(wget -q -O - $url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-    fi
-  fi
-}
-
-# downloadFile downloads the latest binary package and also the checksum
-# for that binary.
-downloadFile() {
-  PLUGIN_TMP_FILE="/tmp/${PROJECT_NAME}.tgz"
-  echo "Downloading $DOWNLOAD_URL"
-  if type "curl" > /dev/null; then
-    curl -L "$DOWNLOAD_URL" -o "$PLUGIN_TMP_FILE"
-  elif type "wget" > /dev/null; then
-    wget -q -O "$PLUGIN_TMP_FILE" "$DOWNLOAD_URL"
-  fi
-}
-
-# installFile verifies the SHA256 for the file, then unpacks and
-# installs it.
-installFile() {
-  HELM_TMP="/tmp/$PROJECT_NAME"
-  mkdir -p "$HELM_TMP"
-  tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
-  HELM_TMP_BIN="$HELM_TMP/diff/bin/diff"
-  echo "Preparing to install into ${HELM_PLUGIN_PATH}"
-  mkdir -p "$HELM_PLUGIN_PATH/bin"
-  cp "$HELM_TMP_BIN" "$HELM_PLUGIN_PATH/bin"
-}
-
-# fail_trap is executed if an error occurs.
-fail_trap() {
-  result=$?
-  if [ "$result" != "0" ]; then
-    echo "Failed to install $PROJECT_NAME"
-    echo "\tFor support, go to https://github.com/databus23/helm-diff."
-  fi
-  exit $result
-}
-
-# testVersion tests the installed client to make sure it is working.
-testVersion() {
-  set +e
-  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH/$PROJECT_NAME"
-  "${HELM_PLUGIN_PATH}/bin/diff" -h
-  set -e
-}
-
-# Execution
-
-#Stop execution on any error
-trap "fail_trap" EXIT
-set -e
-initArch
-initOS
-verifySupported
-getDownloadURL
-downloadFile
-installFile
-testVersion
+tar xzf "releases/v${version}.tar.gz" -C "releases/v${version}"
+mv "releases/v${version}/diff/bin/diff" "bin/diff" || \
+    mv "releases/v${version}/bin/diff/diff.exe" "bin/diff"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,5 +7,5 @@ description: "Preview helm upgrade changes as a diff"
 useTunnel: true
 command: "$HELM_PLUGIN_DIR/bin/diff"
 hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR; ./install-binary.sh"
+  update: "cd $HELM_PLUGIN_DIR; ./install-binary.sh"


### PR DESCRIPTION
Hi

In the current version I'm having problems installing the plugin via helm ant the repo url.

`helm plugin install https://github.com/databus23/helm-diff`

The install process fails with the following error.
```
Use "helm [command] --help" for more information about a command./plugins/helm-diff
mkdir: cannot create directory ‘The Kubernetes package manager\n\nCommon actions for Helm:\n\n- helm search:    search for charts\n- helm fetch:     download a chart to your local directory to view\n- helm install:   upload the chart to Kubernetes\n- helm list:      list releases of charts\n\nEnvironment:\n  $XDG_CACHE_HOME     set an alternative location for storing cached files.\n  $XDG_CONFIG_HOME    set an alternative location for storing Helm configuration.\n  $XDG_DATA_HOME      set an alternative location for storing Helm data.\n  $HELM_DRIVER        set the backend storage driver. Values are: configmap, secret, memory\n  $HELM_NO_PLUGINS    disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.\n  $KUBECONFIG         set an alternative Kubernetes configuration file (default "~’: File name too long
Failed to install helm-diff
\tFor support, go to https://github.com/databus23/helm-diff.
Error: plugin install hook for "diff" exited with error
```

This PR replaces the install script with one inspired by https://github.com/helm/helm-2to3 which solves the install problem.

Best Regards,

Marc