### PR TITLE
change path of install script

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,5 +7,5 @@ description: "Preview helm upgrade changes as a diff"
 useTunnel: true
 command: "$HELM_PLUGIN_DIR/bin/diff"
 hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR; ./install-binary.sh"
+  update: "cd $HELM_PLUGIN_DIR; ./install-binary.sh"


### PR DESCRIPTION
This PR sets the path of the install and update script. 

Without this dir change the helm plugin install failed with helm3.

Regards,
bakito