### PR TITLE
app option to pass apiVersions to helm

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -89,7 +89,9 @@ func (d *diffCmd) template() ([]byte, error) {
 	for _, fileValue := range d.fileValues {
 		flags = append(flags, "--set-file", fileValue)
 	}
-
+	for _, apiVersion := range d.apiVersions {
+		flags = append(flags, "--api-versions", apiVersion)
+	}
 	//This is a workaround until https://github.com/helm/helm/pull/6729 is released
 	for _, apiVersion := range strings.Split(os.Getenv("HELM_TEMPLATE_API_VERSIONS"), ",") {
 		if apiVersion != "" {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,6 +32,7 @@ type diffCmd struct {
 	includeTests     bool
 	suppressedKinds  []string
 	outputContext    int
+	apiVersions      []string
 }
 
 const globalUsage = `Show a diff explaining what a helm upgrade would change.
@@ -94,6 +95,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 	f.StringArrayVar(&diff.suppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
 	f.IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
+	f.StringArrayVar(&diff.apiVersions, "api-versions", []string{}, "API versions to pass to helm")
 	if !isHelm3() {
 		f.StringVar(&diff.namespace, "namespace", "default", "namespace to assume the release to be installed into")
 	}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.0.0-rc.7"
+version: "3.0.0-rc.8"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This PR adds a new flag `--api-versions` which values are passed to `helm template`.

The flag can be used to explicitly specify the API Versions which are expected to be supported by the cluster, in order to avoid getting unexpected results with helm charts checking for `Capabilities.APIVersions`.

This feature in `helm-diff` will enable the same option flag in `helmfile` (see https://github.com/roboll/helmfile/issues/1014 and https://github.com/roboll/helmfile/pull/1046)