### PR TITLE
Disabling grep colouring mode directly for the execution

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -4,6 +4,7 @@
 
 PROJECT_NAME="helm-diff"
 PROJECT_GH="databus23/$PROJECT_NAME"
+GREP_COLOR="never"
 
 : ${HELM_PLUGIN_DIR:="$(helm home --debug=false)/plugins/helm-diff"}
 


### PR DESCRIPTION
## Short description
Disabling grep colouring mode directly for the execution, because it causes issues when accessing the url with curl if `GREP_COLOR` is set to `always`.

As you can see below, curl will use invalid url set by `getDownloadURL` function. The issue is in line 76 of the install/update script where the OS name is grepped. (https://github.com/databus23/helm-diff/blob/master/install-binary.sh#L76)

If colouring mode is disabled for grep, it will not include the terminal colouring chars in the download url and the new release can be downloaded.

```
curl: (3) bad range in URL position 82: https://github.com/databus23/helm-diff/releases/download/v3.0.0-rc.7/helm-diff-\u001b[01;31m\u001b[Kmacos\u001b[m\u001b[K.tgz
```

## Full error message
```
TASK [helm_diff : Update helm diff plugin] ****************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => { 
    "changed":true,
    "cmd":[ 
        "helm",
        "plugin",
        "update",
        "diff"
    ],
    "delta":"0:00:01.899889",
    "end":"2020-01-14 13:16:33.103668",
    "msg":"non-zero return code",
    "rc":1,
    "start":"2020-01-14 13:16:31.203779",
    "stderr":"curl: (3) bad range in URL position 82:\nhttps://github.com/databus23/helm-diff/releases/download/v3.0.0-rc.7/helm-diff-\u001b[01;31m\u001b[Kmacos\u001b[m\u001b[K.tgz\n                                                                                 ^\nError: Failed to update plugin diff, got error (plugin update hook for \"diff\" exited with error)",
    "stderr_lines":[ 
        "curl: (3) bad range in URL position 82:",
        "https://github.com/databus23/helm-diff/releases/download/v3.0.0-rc.7/helm-diff-\u001b[01;31m\u001b[Kmacos\u001b[m\u001b[K.tgz",
        "                                                                                 ^",
        "Error: Failed to update plugin diff, got error (plugin update hook for \"diff\" exited with error)"
    ],
    "stdout":"Downloading https://github.com/databus23/helm-diff/releases/download/v3.0.0-rc.7/helm-diff-\u001b[01;31m\u001b[Kmacos\u001b[m\u001b[K.tgz\nFailed to install helm-diff\n\\tFor support, go to https://github.com/databus23/helm-diff.",
    "stdout_lines":[ 
        "Downloading https://github.com/databus23/helm-diff/releases/download/v3.0.0-rc.7/helm-diff-\u001b[01;31m\u001b[Kmacos\u001b[m\u001b[K.tgz",
        "Failed to install helm-diff",
        "\\tFor support, go to https://github.com/databus23/helm-diff."
    ]
}
```