### PR TITLE
Add support for Helm 3 --disable-openapi-validation flag

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -81,7 +81,7 @@ func getChart(release, namespace string) (string, error) {
 	return string(out), nil
 }
 
-func (d *diffCmd) template(isUpgrade bool, disableOpenAPIValidation bool) ([]byte, error) {
+func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	flags := []string{}
 	if d.devel {
 		flags = append(flags, "--devel")
@@ -129,7 +129,7 @@ func (d *diffCmd) template(isUpgrade bool, disableOpenAPIValidation bool) ([]byt
 		flags = append(flags, "--is-upgrade")
 	}
 
-	if disableOpenAPIValidation {
+	if d.disableOpenAPIValidation {
 		flags = append(flags, "--disable-openapi-validation")
 	}
 

--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -81,7 +81,7 @@ func getChart(release, namespace string) (string, error) {
 	return string(out), nil
 }
 
-func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
+func (d *diffCmd) template(isUpgrade bool, disableOpenAPIValidation bool) ([]byte, error) {
 	flags := []string{}
 	if d.devel {
 		flags = append(flags, "--devel")
@@ -127,6 +127,10 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 
 	if isUpgrade {
 		flags = append(flags, "--is-upgrade")
+	}
+
+	if disableOpenAPIValidation {
+		flags = append(flags, "--disable-openapi-validation")
 	}
 
 	args := []string{"template", d.release, d.chart}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -132,7 +132,7 @@ func (d *diffCmd) runHelm3() error {
 		return fmt.Errorf("Failed to get release %s in namespace %s: %s", d.release, d.namespace, err)
 	}
 
-	installManifest, err := d.template(!newInstall, d.disableOpenAPIValidation)
+	installManifest, err := d.template(!newInstall)
 	if err != nil {
 		return fmt.Errorf("Failed to render chart: %s", err)
 	}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.1.0"
+version: "3.1.1"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Added disable-openapi-validation helm3 flag support to disable rendered templates validation with the Kubernetes OpenAPI Schema.
https://github.com/helm/helm/pull/7570
It fixes https://github.com/databus23/helm-diff/issues/209