### PR TITLE
feat: JSON output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ PKG:= github.com/databus23/helm-diff
 LDFLAGS := -X $(PKG)/cmd.Version=$(VERSION)
 
 # Clear the "unreleased" string in BuildMetadata
-LDFLAGS += -X $(PKG)/vendor/k8s.io/helm/pkg/version.BuildMetadata=
-LDFLAGS += -X $(PKG)/vendor/k8s.io/helm/pkg/version.Version=$(shell grep -A1 "package: k8s.io/helm" go.mod | sed -n -e 's/[ ]*version:.*\(v[.0-9]*\).*/\1/p')
+LDFLAGS += -X k8s.io/helm/pkg/version.BuildMetadata=
+LDFLAGS += -X k8s.io/helm/pkg/version.Version=$(shell ./scripts/dep-helm-version.sh)
 
 .PHONY: format
 format:
-	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
-	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
+	test -z "$$(find . -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
+	test -z "$$(find . -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"
 
 .PHONY: install
 install: build

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -112,7 +112,7 @@ func newChartCommand() *cobra.Command {
 	f.IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.BoolVar(&diff.disableOpenAPIValidation, "disable-openapi-validation", false, "disables rendered templates validation against the Kubernetes OpenAPI Schema")
 	f.StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
-	f.StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	f.StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, json, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	if !isHelm3() {
 		f.StringVar(&diff.namespace, "namespace", "default", "namespace to assume the release to be installed into")
 	}

--- a/diff/constant.go
+++ b/diff/constant.go
@@ -4,10 +4,10 @@ const defaultTemplateReport = `[
 {{- $global := . -}}
 {{- range $idx, $entry := . -}}
 {
-  "Api": "{{ $entry.API }}",
-  "Kind": "{{ $entry.Kind }}",
-  "Namespace": "{{ $entry.Namespace }}",
-  "Name": "{{ $entry.Name }}",
-  "Change": "{{ $entry.Change }}"
+  "api": "{{ $entry.API }}",
+  "kind": "{{ $entry.Kind }}",
+  "namespace": "{{ $entry.Namespace }}",
+  "name": "{{ $entry.Name }}",
+  "change": "{{ $entry.Change }}"
 }{{ if not (last $idx  $global) }},{{ end }}
 {{- end }}]`

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -216,12 +216,31 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 		}
 
 		require.Equal(t, `[{
-  "Api": "apps",
-  "Kind": "Deployment",
-  "Namespace": "default",
-  "Name": "nginx",
-  "Change": "MODIFY"
-}]`, buf1.String())
+  "api": "apps",
+  "kind": "Deployment",
+  "namespace": "default",
+  "name": "nginx",
+  "change": "MODIFY"
+}]
+`, buf1.String())
+	})
+
+	t.Run("OnChangeJSON", func(t *testing.T) {
+
+		var buf1 bytes.Buffer
+
+		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "json", &buf1); !changesSeen {
+			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
+		}
+
+		require.Equal(t, `[{
+  "api": "apps",
+  "kind": "Deployment",
+  "namespace": "default",
+  "name": "nginx",
+  "change": "MODIFY"
+}]
+`, buf1.String())
 	})
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
@@ -231,7 +250,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 
-		require.Equal(t, "[]", buf2.String())
+		require.Equal(t, "[]\n", buf2.String())
 	})
 
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
@@ -241,6 +260,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 
-		require.Equal(t, "Resource name: nginx", buf1.String())
+		require.Equal(t, "Resource name: nginx\n", buf1.String())
 	})
 }


### PR DESCRIPTION
This adds the JSON output on top of #221, which can be enabled by passing `--output json`. Internally it works exactly the same as the `template` output format with the default template.

```
********************

        Release was not present in Helm.  Diff will show entire contents as new.

********************
[{
  "api": "v1",
  "kind": "Secret",
  "namespace": "default",
  "name": "mysql-1567775891",
  "change": "ADD"
},{
  "api": "v1",
  "kind": "ConfigMap",
  "namespace": "default",
  "name": "mysql-1567775891-test",
  "change": "ADD"
},{
  "api": "v1",
  "kind": "PersistentVolumeClaim",
  "namespace": "default",
  "name": "mysql-1567775891",
  "change": "ADD"
},{
  "api": "v1",
  "kind": "Service",
  "namespace": "default",
  "name": "mysql-1567775891",
  "change": "ADD"
},{
  "api": "apps",
  "kind": "Deployment",
  "namespace": "default",
  "name": "mysql-1567775891",
  "change": "ADD"
}]
```

Also note that I've modified the default template a bit so that it looks more like helm's output. See `helm list -o json` for example.

Ref https://github.com/databus23/helm-diff/pull/221#pullrequestreview-451199381