### PR TITLE
Add --disable-validation for disabling validation against K8s cluster entirely

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -126,7 +126,9 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 		flags = append(flags, "--set-file", fileValue)
 	}
 
-	flags = append(flags, "--validate")
+	if !d.disableValidation {
+		flags = append(flags, "--validate")
+	}
 
 	if isUpgrade {
 		flags = append(flags, "--is-upgrade")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -20,6 +20,7 @@ type diffCmd struct {
 	client                   helm.Interface
 	detailedExitCode         bool
 	devel                    bool
+	disableValidation        bool
 	disableOpenAPIValidation bool
 	namespace                string // namespace to assume the release to be installed into. Defaults to the current kube config namespace.
 	valueFiles               valueFiles
@@ -110,6 +111,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 	f.StringArrayVar(&diff.suppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
 	f.IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
+	f.BoolVar(&diff.disableValidation, "disable-validation", false, "disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install")
 	f.BoolVar(&diff.disableOpenAPIValidation, "disable-openapi-validation", false, "disables rendered templates validation against the Kubernetes OpenAPI Schema")
 	f.StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
 	f.StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, json, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")


### PR DESCRIPTION
`--disable-openapi-validation` seems to not work against charts like prometheus-operator because it results in "missing kind" errors due to that it tries to install CRD and CR on first install. That is different than OpenAPI schema validation, which seems rather for detecting invalid fields.

The addition of `--disable-validation` disables the manifests validation against the targeted K8s cluster(again, since Helm 3 `helm template --validate` runs validation against the live cluster so it is relevant), so that we can make use of helm-diff even for cases `--disable-openapi-validation` doesn not work.

Resolves #183