### PR TITLE
Make diff result as deterministic as possible

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -102,7 +102,7 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	// Let's simulate that in helm-diff.
 	// See https://medium.com/@kcatstack/understand-helm-upgrade-flags-reset-values-reuse-values-6e58ac8f127e
 	shouldDefaultReusingValues := isUpgrade && len(d.values) == 0 && len(d.stringValues) == 0 && len(d.valueFiles) == 0 && len(d.fileValues) == 0
-	if (d.reuseValues || shouldDefaultReusingValues) && !d.resetValues {
+	if (d.reuseValues || shouldDefaultReusingValues) && !d.resetValues && !d.dryRun {
 		tmpfile, err := ioutil.TempFile("", "existing-values")
 		if err != nil {
 			return nil, err
@@ -126,7 +126,7 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 		flags = append(flags, "--set-file", fileValue)
 	}
 
-	if !d.disableValidation {
+	if !d.disableValidation && !d.dryRun {
 		flags = append(flags, "--validate")
 	}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -23,7 +23,9 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, suppressed
 	report.setupReportFormat(output)
 	seenAnyChanges := false
 	emptyMapping := &manifest.MappingResult{}
-	for key, oldContent := range oldIndex {
+	for _, key := range sortedKeys(oldIndex) {
+		oldContent := oldIndex[key]
+
 		if newContent, ok := newIndex[key]; ok {
 			if oldContent.Content != newContent.Content {
 				// modified
@@ -51,7 +53,9 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, suppressed
 		}
 	}
 
-	for key, newContent := range newIndex {
+	for _, key := range sortedKeys(newIndex) {
+		newContent := newIndex[key]
+
 		if _, ok := oldIndex[key]; !ok {
 			// added
 			if !showSecrets {
@@ -261,4 +265,16 @@ func reIndexForRelease(index map[string]*manifest.MappingResult) map[string]*man
 		}
 	}
 	return newIndex
+}
+
+func sortedKeys(manifests map[string]*manifest.MappingResult) []string {
+	var keys []string
+
+	for key := range manifests {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }


### PR DESCRIPTION
Depends on #230

`helm diff upgrade` output is non-determinisic, due to that it shows diff entry in the order of the Go map objects containing source/target maniefsts to be compared.

The non-determinism makes writing integration test with something and helm-diff harder, as snapshot testing is impossible.

This patch fixes it by enhancing the diff logic to sort those map keys in the alphabetical order and use the result for iterating map entries.

Note that you can use the below snippet for non-scientific testing to verify that the result is (seemingly) deterministic now:

```
for (( i=0; i<10; ++i)); do helm --debug diff upgrade --dry-run foo stable/prometheus-operator | sha256sum ; done
```

Before this change it should print output like:

```
$ for (( i=0; i<10; ++i)); do helm --debug diff upgrade --dry-run foo stable/prometheus-operator | sha256sum ; done
754f01763544baeb4f405ccdcdf7ffd9075bfddf9777a993f1e787ea6096b0b4  -
88a5f76e3802e0e4693fe007d4ae6fc8c3ae5cf97b7244dc67e45a282385e2c3  -
b57e66a22c49ec2a29dacc9e912a313aca85b403ac3d2960fc0afddeda544a77  -
769c605ea8c13f4251559948260f8c6104d821ce79de1367d2a6ee477be37777  -
afce52fa595beaf106303ae162efb4f31a7336c84a630b1d4ea1e59ba1468292  -
12a3b3c1e3fdcd0b4b62517583135abe20249d69e6c4aed9acfab7c999771bdd  -
294d5db8edec946737036014b549baa93601aadf430f1b80517db9eca2dd1330  -
31860127c9ae69e5d0154b60cc7ea05e992bac54e1453c88198940e719552f72  -
dce05e1932ca7d6e15416de3b0a891ae68e3c885247f683fe50068b2c551213b  -
f0101d6e952fd0344d9e45518254cb3e0692156becaae106fcc7b1dae273ac04  -
```

After the change it should be like:

```
$ make build install/helm3
$ for (( i=0; i<10; ++i)); do helm --debug diff upgrade --dry-run foo stable/prometheus-operator | sha256sum ; done
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
ee4e79f6adee9e2606c9d855949afd39cf5a13a650cb55a3d74184c7edaf956d  -
```