### PR TITLE
Added unset for GREP_OPTIONS

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,6 +5,7 @@
 PROJECT_NAME="helm-diff"
 PROJECT_GH="databus23/$PROJECT_NAME"
 export GREP_COLOR="never"
+unset GREP_OPTIONS
 
 HELM_MAJOR_VERSION=$(helm version --client --short | awk -F '.' '{print $1}')
 


### PR DESCRIPTION
Setting both `GREP_OPTIONS="--color=always"` and `GREP_COLOR=never` conflict and color is not always turned off on MacOS.

If users have GREP_OPTIONS set in in their env variables, then extra characters are inserted into the download url. Then a not found is returned (curl exit code isn't checked), and tar is run against a the text http response.

Running the `unset` prior to running the install command worked to resolve the issue.

Error output looks like:
```
[bobert@mac helmfile_exmaple]$ helm plugin install https://github.com/databus23/helm-diff --debug
[debug] vcs_installer.go:162: updating https://github.com/databus23/helm-diff
[debug] vcs_installer.go:91: copying /Users/p2338715/Library/Caches/helm/plugins/https-github.com-databus23-helm-diff to /Users/p2338715/Library/helm/plugins/helm-diff
plugin_install.go:73: [debug] loading plugin from /Users/p2338715/Library/helm/plugins/helm-diff
plugin.go:60: [debug] running install hook: /bin/sh -c $HELM_PLUGIN_DIR/install-binary.sh
Downloading https://github.com/databus23/helm-diff/releases/download/v3.1.3/helm-diff-evermmacos.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1438    0  1438    0     0   3428      0 --:--:-- --:--:-- --:--:--  3423
tar: Unrecognized archive format
tar: Error exit delayed from previous errors.
Failed to install helm-diff
	For support, go to https://github.com/databus23/helm-diff.
Error: plugin install hook for "diff" exited with error
helm.go:84: [debug] plugin install hook for "diff" exited with error
```

This probably also affects:
`# Shamelessly copied from https://github.com/technosophos/helm-template`

