### PR TITLE
add support for strip-trailing-cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Flags:
       --post-renderer string   the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path
       --reset-values           reset the values to the ones built into the chart and merge in any new values
       --reuse-values           reuse the last release's values and merge in any new values
+      --strip-trailing-cr      strip trailing carriage return on input
       --set stringArray        set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --suppress stringArray   allows suppression of the values listed in the diff output
   -q, --suppress-secrets       suppress secrets in the output
@@ -135,6 +136,7 @@ Flags:
   -h, --help                   help for release
       --home string            location of your Helm config. Overrides $HELM_HOME (default "/home/aananth/.helm")
       --include-tests          enable the diffing of the helm test hooks
+      --strip-trailing-cr      strip trailing carriage return on input
       --suppress stringArray   allows suppression of the values listed in the diff output
   -q, --suppress-secrets       suppress secrets in the output
       --tls                    enable TLS for request
@@ -172,6 +174,7 @@ Usage:
 
 Flags:
   -h, --help                   help for revision
+      --strip-trailing-cr      strip trailing carriage return on input
       --suppress stringArray   allows suppression of the values listed in the diff output
   -q, --suppress-secrets       suppress secrets in the output
 
@@ -197,6 +200,7 @@ Examples:
 
 Flags:
   -h, --help                   help for rollback
+      --strip-trailing-cr      strip trailing carriage return on input
       --suppress stringArray   allows suppression of the values listed in the diff output
   -q, --suppress-secrets       suppress secrets in the output
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -21,6 +21,7 @@ type release struct {
 	includeTests     bool
 	showSecrets      bool
 	output           string
+	stripTrailingCR  bool
 }
 
 const releaseCmdLongUsage = `
@@ -79,6 +80,7 @@ func releaseCmd() *cobra.Command {
 	releaseCmd.Flags().IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
 	releaseCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	releaseCmd.Flags().StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	releaseCmd.Flags().BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 
 	releaseCmd.SuggestionsMinimumDistance = 1
 
@@ -121,6 +123,7 @@ func (d *release) differentiateHelm3() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 		if d.detailedExitCode && seenAnyChanges {
@@ -155,6 +158,7 @@ func (d *release) differentiate() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 		if d.detailedExitCode && seenAnyChanges {

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -23,6 +23,7 @@ type revision struct {
 	includeTests     bool
 	showSecrets      bool
 	output           string
+	stripTrailingCR  bool
 }
 
 const revisionCmdLongUsage = `
@@ -89,6 +90,7 @@ func revisionCmd() *cobra.Command {
 	revisionCmd.Flags().IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
 	revisionCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	revisionCmd.Flags().StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	revisionCmd.Flags().BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 
 	revisionCmd.SuggestionsMinimumDistance = 1
 
@@ -126,6 +128,7 @@ func (d *revision) differentiateHelm3() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 	case 2:
@@ -152,6 +155,7 @@ func (d *revision) differentiateHelm3() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 		if d.detailedExitCode && seenAnyChanges {
@@ -191,6 +195,7 @@ func (d *revision) differentiate() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 	case 2:
@@ -217,6 +222,7 @@ func (d *revision) differentiate() error {
 			d.showSecrets,
 			d.outputContext,
 			d.output,
+			d.stripTrailingCR,
 			os.Stdout)
 
 		if d.detailedExitCode && seenAnyChanges {

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -23,6 +23,7 @@ type rollback struct {
 	includeTests     bool
 	showSecrets      bool
 	output           string
+	stripTrailingCR  bool
 }
 
 const rollbackCmdLongUsage = `
@@ -81,6 +82,7 @@ func rollbackCmd() *cobra.Command {
 	rollbackCmd.Flags().IntVarP(&diff.outputContext, "context", "C", -1, "output NUM lines of context around changes")
 	rollbackCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	rollbackCmd.Flags().StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	rollbackCmd.Flags().BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 
 	rollbackCmd.SuggestionsMinimumDistance = 1
 
@@ -119,6 +121,7 @@ func (d *rollback) backcastHelm3() error {
 		d.showSecrets,
 		d.outputContext,
 		d.output,
+		d.stripTrailingCR,
 		os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {
@@ -155,6 +158,7 @@ func (d *rollback) backcast() error {
 		d.showSecrets,
 		d.outputContext,
 		d.output,
+		d.stripTrailingCR,
 		os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -39,6 +39,7 @@ type diffCmd struct {
 	postRenderer             string
 	output                   string
 	install                  bool
+	stripTrailingCR          bool
 }
 
 func (d *diffCmd) isAllowUnreleased() bool {
@@ -117,6 +118,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.dryRun, "dry-run", false, "disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation")
 	f.StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
 	f.StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, json, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	f.BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 	if !isHelm3() {
 		f.StringVar(&diff.namespace, "namespace", "default", "namespace to assume the release to be installed into")
 	}
@@ -184,7 +186,7 @@ func (d *diffCmd) runHelm3() error {
 	} else {
 		newSpecs = manifest.Parse(string(installManifest), d.namespace, helm3TestHook, helm2TestSuccessHook)
 	}
-	seenAnyChanges := diff.Manifests(currentSpecs, newSpecs, d.suppressedKinds, d.showSecrets, d.outputContext, d.output, os.Stdout)
+	seenAnyChanges := diff.Manifests(currentSpecs, newSpecs, d.suppressedKinds, d.showSecrets, d.outputContext, d.output, d.stripTrailingCR, os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {
 		return Error{
@@ -270,7 +272,8 @@ func (d *diffCmd) run() error {
 		}
 	}
 
-	seenAnyChanges := diff.Manifests(currentSpecs, newSpecs, d.suppressedKinds, d.showSecrets, d.outputContext, d.output, os.Stdout)
+	println("#######################################################################################################################################*******************************************************")
+	seenAnyChanges := diff.Manifests(currentSpecs, newSpecs, d.suppressedKinds, d.showSecrets, d.outputContext, d.output, d.stripTrailingCR, os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {
 		return Error{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -272,7 +272,6 @@ func (d *diffCmd) run() error {
 		}
 	}
 
-	println("#######################################################################################################################################*******************************************************")
 	seenAnyChanges := diff.Manifests(currentSpecs, newSpecs, d.suppressedKinds, d.showSecrets, d.outputContext, d.output, d.stripTrailingCR, os.Stdout)
 
 	if d.detailedExitCode && seenAnyChanges {


### PR DESCRIPTION
This PR add support to strip the trailing cr from charts that have been deployed wit different line endings.

See #144