### PR TITLE
Automatically color output based on whether output is a terminal

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
-	"os"
 )
 
 const rootCmdLongUsage = `

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+	"os"
 )
 
 const rootCmdLongUsage = `
@@ -40,6 +42,8 @@ func New() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if nc, _ := cmd.Flags().GetBool("no-color"); nc {
 				ansi.DisableColors(true)
+			} else if !cmd.Flags().Changed("no-color") {
+				ansi.DisableColors(!terminal.IsTerminal(int(os.Stdout.Fd())))
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	google.golang.org/grpc v1.30.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.6


### PR DESCRIPTION
In the absence of an explicit `--no-color` flag specification, try to infer whether the standard output is a terminal, and only emit colored output when it is.
This only affects invocations without the flag, all of `--no-color`, `--no-color=false`, and `--no-color=true` retain their original semantics.

See example:
<img width="611" alt="Screen Shot 2020-09-10 at 23 54 47" src="https://user-images.githubusercontent.com/2822367/92813526-a3c42580-f3c1-11ea-8701-0a3d68c55ae6.png">
