### PR TITLE
Ignore unknown flags for upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -90,6 +90,9 @@ func newChartCommand() *cobra.Command {
 			}
 			return diff.run()
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 
 	f := cmd.Flags()


### PR DESCRIPTION
Hello.

This PR is meant for people like me who want to use `--atomic` and also like to run `helm upgrade` by simply removing `diff` from the command line.

It allows to run `helm diff upgrade --atomic ...` without getting `Error: unknown flag: --atomic`.

