### PR TITLE
Change to use $HELM_HOME

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -6,9 +6,7 @@ PROJECT_NAME="helm-diff"
 PROJECT_GH="databus23/$PROJECT_NAME"
 export GREP_COLOR="never"
 
-HELM_MAJOR_VERSION=$(helm version --client --short | awk -F '.' '{print $1}')
-
-: ${HELM_PLUGIN_DIR:="$(helm home --debug=false)/plugins/helm-diff"}
+: ${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/helm-diff"}
 
 # Convert the HELM_PLUGIN_DIR to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin


### PR DESCRIPTION
This variable should be populated when using `helm plugin install`

Fixes #244 