### PR TITLE
Only re-use user specified values

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -145,7 +145,7 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 }
 
 func (d *diffCmd) writeExistingValues(f *os.File) error {
-	cmd := exec.Command(os.Getenv("HELM_BIN"), "get", "values", d.release, "--all", "--output", "yaml")
+	cmd := exec.Command(os.Getenv("HELM_BIN"), "get", "values", d.release, "--output", "yaml")
 	debugPrint("Executing %s", strings.Join(cmd.Args, " "))
 	defer f.Close()
 	cmd.Stdout = f


### PR DESCRIPTION
Helm only re-uses the values specified by the user. Re-using *all* values, including the values set by the chart, when diffing, removes values updated in the charts' values files from the diff. This result in a false, smaller diff, not showing how it would look when installed.

Resolves #248 