### PR TITLE
diff/report: fix key regexp

### DIFF
--- a/diff/report.go
+++ b/diff/report.go
@@ -193,7 +193,7 @@ func setupTemplateReport(r *Report) {
 // report with template output will only have access to ReportTemplateSpec.
 // This function reverts parsedMetadata.String()
 func (t *ReportTemplateSpec) loadFromKey(key string) error {
-	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9-]+), (?P<kind>\w+) \((?P<api>[a-z0-9.]+)\)`)
+	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9-]+), (?P<kind>\w+) \((?P<api>[^)]+)\)`)
 	matches := pattern.FindStringSubmatch(key)
 	if len(matches) > 1 {
 		t.Namespace = matches[1]


### PR DESCRIPTION
The current regexp doesn't match all possible apis, for example
`cert-manager.io`.

As there is a closing `)` we can simply take everything before it.