### PR TITLE
helm-diff doesn't include values from stdin for helm3 version

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -120,7 +120,26 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 		flags = append(flags, "--set-string", stringValue)
 	}
 	for _, valueFile := range d.valueFiles {
-		flags = append(flags, "--values", valueFile)
+		if strings.TrimSpace(valueFile) == "-" {
+			var bytes []byte
+			var err error
+
+			bytes, err = ioutil.ReadAll(os.Stdin)
+
+			tmpfile, err := ioutil.TempFile("", "stdin-values")
+			if err != nil {
+				return nil, err
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write(bytes); err != nil {
+				return nil, err
+			}
+
+			flags = append(flags, "--values", tmpfile.Name())
+		} else {
+			flags = append(flags, "--values", valueFile)
+		}
 	}
 	for _, fileValue := range d.fileValues {
 		flags = append(flags, "--set-file", fileValue)

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -3,7 +3,7 @@
 # Shamelessly copied from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-diff"
-PROJECT_GH="databus23/$PROJECT_NAME"
+PROJECT_GH="ruslanloman/$PROJECT_NAME"
 export GREP_COLOR="never"
 
 HELM_MAJOR_VERSION=$(helm version --client --short | awk -F '.' '{print $1}')

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.1.3"
+version: "3.1.4"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Hi,
This PR fixes issue with missed values from stdin for helm3 version. 

Current behavior:
```
$ cat values-10.yaml
lolkek:
  helloword: test
  new:
    ohoho:
      values-10: lolodddd10

$ cat values-10.yaml | helm3 diff upgrade test_helm . --allow-unreleased --values -

+ # Source: test_helm/templates/configMap.yaml
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: game-demo
+ data:
+   user-interface.properties: |
+     null
```
With applied fix:
```
$ cat values-10.yaml | helm3 diff upgrade test_helm . --allow-unreleased --values -
 
+ # Source: test_helm/templates/configMap.yaml
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: game-demo
+ data:
+   user-interface.properties: |
+     ohoho:
+       values-10: lolodddd10
```