### PR TITLE
Normalize YAML manifests before running diff

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -13,15 +13,16 @@ import (
 )
 
 type release struct {
-	client           helm.Interface
-	detailedExitCode bool
-	suppressedKinds  []string
-	releases         []string
-	outputContext    int
-	includeTests     bool
-	showSecrets      bool
-	output           string
-	stripTrailingCR  bool
+	client             helm.Interface
+	detailedExitCode   bool
+	suppressedKinds    []string
+	releases           []string
+	outputContext      int
+	includeTests       bool
+	showSecrets        bool
+	output             string
+	stripTrailingCR    bool
+	normalizeManifests bool
 }
 
 const releaseCmdLongUsage = `
@@ -81,6 +82,7 @@ func releaseCmd() *cobra.Command {
 	releaseCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	releaseCmd.Flags().StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	releaseCmd.Flags().BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
+	releaseCmd.Flags().BoolVar(&diff.normalizeManifests, "normalize-manifests", false, "normalize manifests before running diff to exclude style differences from the output")
 
 	releaseCmd.SuggestionsMinimumDistance = 1
 
@@ -117,8 +119,8 @@ func (d *release) differentiateHelm3() error {
 
 	if releaseChart1 == releaseChart2 {
 		seenAnyChanges := diff.Releases(
-			manifest.Parse(string(releaseResponse1), namespace, excludes...),
-			manifest.Parse(string(releaseResponse2), namespace, excludes...),
+			manifest.Parse(string(releaseResponse1), namespace, d.normalizeManifests, excludes...),
+			manifest.Parse(string(releaseResponse2), namespace, d.normalizeManifests, excludes...),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,
@@ -152,8 +154,8 @@ func (d *release) differentiate() error {
 
 	if releaseResponse1.Release.Chart.Metadata.Name == releaseResponse2.Release.Chart.Metadata.Name {
 		seenAnyChanges := diff.Releases(
-			manifest.ParseRelease(releaseResponse1.Release, d.includeTests),
-			manifest.ParseRelease(releaseResponse2.Release, d.includeTests),
+			manifest.ParseRelease(releaseResponse1.Release, d.includeTests, d.normalizeManifests),
+			manifest.ParseRelease(releaseResponse2.Release, d.includeTests, d.normalizeManifests),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -14,16 +14,17 @@ import (
 )
 
 type revision struct {
-	release          string
-	client           helm.Interface
-	detailedExitCode bool
-	suppressedKinds  []string
-	revisions        []string
-	outputContext    int
-	includeTests     bool
-	showSecrets      bool
-	output           string
-	stripTrailingCR  bool
+	release            string
+	client             helm.Interface
+	detailedExitCode   bool
+	suppressedKinds    []string
+	revisions          []string
+	outputContext      int
+	includeTests       bool
+	showSecrets        bool
+	output             string
+	stripTrailingCR    bool
+	normalizeManifests bool
 }
 
 const revisionCmdLongUsage = `
@@ -91,6 +92,7 @@ func revisionCmd() *cobra.Command {
 	revisionCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	revisionCmd.Flags().StringVar(&diff.output, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	revisionCmd.Flags().BoolVar(&diff.stripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
+	revisionCmd.Flags().BoolVar(&diff.normalizeManifests, "normalize-manifests", false, "normalize manifests before running diff to exclude style differences from the output")
 
 	revisionCmd.SuggestionsMinimumDistance = 1
 
@@ -122,8 +124,8 @@ func (d *revision) differentiateHelm3() error {
 		}
 
 		diff.Manifests(
-			manifest.Parse(string(revisionResponse), namespace, excludes...),
-			manifest.Parse(string(releaseResponse), namespace, excludes...),
+			manifest.Parse(string(revisionResponse), namespace, d.normalizeManifests, excludes...),
+			manifest.Parse(string(releaseResponse), namespace, d.normalizeManifests, excludes...),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,
@@ -149,8 +151,8 @@ func (d *revision) differentiateHelm3() error {
 		}
 
 		seenAnyChanges := diff.Manifests(
-			manifest.Parse(string(revisionResponse1), namespace, excludes...),
-			manifest.Parse(string(revisionResponse2), namespace, excludes...),
+			manifest.Parse(string(revisionResponse1), namespace, d.normalizeManifests, excludes...),
+			manifest.Parse(string(revisionResponse2), namespace, d.normalizeManifests, excludes...),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,
@@ -189,8 +191,8 @@ func (d *revision) differentiate() error {
 		}
 
 		diff.Manifests(
-			manifest.ParseRelease(revisionResponse.Release, d.includeTests),
-			manifest.ParseRelease(releaseResponse.Release, d.includeTests),
+			manifest.ParseRelease(revisionResponse.Release, d.includeTests, d.normalizeManifests),
+			manifest.ParseRelease(releaseResponse.Release, d.includeTests, d.normalizeManifests),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,
@@ -216,8 +218,8 @@ func (d *revision) differentiate() error {
 		}
 
 		seenAnyChanges := diff.Manifests(
-			manifest.ParseRelease(revisionResponse1.Release, d.includeTests),
-			manifest.ParseRelease(revisionResponse2.Release, d.includeTests),
+			manifest.ParseRelease(revisionResponse1.Release, d.includeTests, d.normalizeManifests),
+			manifest.ParseRelease(revisionResponse2.Release, d.includeTests, d.normalizeManifests),
 			d.suppressedKinds,
 			d.showSecrets,
 			d.outputContext,

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -135,7 +135,7 @@ func parseContent(content string, defaultNamespace string, excludedHooks ...stri
 
 	if parsedMetadata.Kind == "List" {
 		type ListV1 struct {
-			Items []yaml.MapSlice `yaml:"items"`
+			Items []map[interface{}]interface{} `yaml:"items"`
 		}
 
 		var list ListV1
@@ -162,6 +162,16 @@ func parseContent(content string, defaultNamespace string, excludedHooks ...stri
 
 		return result, nil
 	}
+
+	var object map[interface{}]interface{}
+	if err := yaml.Unmarshal([]byte(content), &object); err != nil {
+		log.Fatalf("YAML unmarshal error: %s\nCan't unmarshal %s", err, content)
+	}
+	normalizedContent, err := yaml.Marshal(object)
+	if err != nil {
+		log.Fatalf("YAML marshal error: %s\nCan't marshal %v", err, object)
+	}
+	content = string(normalizedContent)
 
 	if isHook(parsedMetadata, excludedHooks...) {
 		return nil, nil

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -25,7 +25,7 @@ func TestPod(t *testing.T) {
 
 	require.Equal(t,
 		[]string{"default, nginx, Pod (v1)"},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
 
@@ -35,7 +35,7 @@ func TestPodNamespace(t *testing.T) {
 
 	require.Equal(t,
 		[]string{"batcave, nginx, Pod (v1)"},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
 
@@ -45,17 +45,17 @@ func TestPodHook(t *testing.T) {
 
 	require.Equal(t,
 		[]string{"default, nginx, Pod (v1)"},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 
 	require.Equal(t,
 		[]string{"default, nginx, Pod (v1)"},
-		foundObjects(Parse(string(spec), "default", "test-success")),
+		foundObjects(Parse(string(spec), "default", false, "test-success")),
 	)
 
 	require.Equal(t,
 		[]string{},
-		foundObjects(Parse(string(spec), "default", "test")),
+		foundObjects(Parse(string(spec), "default", false, "test")),
 	)
 }
 
@@ -65,7 +65,7 @@ func TestDeployV1(t *testing.T) {
 
 	require.Equal(t,
 		[]string{"default, nginx, Deployment (apps)"},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
 
@@ -75,7 +75,7 @@ func TestDeployV1Beta1(t *testing.T) {
 
 	require.Equal(t,
 		[]string{"default, nginx, Deployment (apps)"},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
 
@@ -88,7 +88,7 @@ func TestList(t *testing.T) {
 			"default, prometheus-operator-example, PrometheusRule (monitoring.coreos.com)",
 			"default, prometheus-operator-example2, PrometheusRule (monitoring.coreos.com)",
 		},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
 
@@ -98,6 +98,6 @@ func TestEmpty(t *testing.T) {
 
 	require.Equal(t,
 		[]string{},
-		foundObjects(Parse(string(spec), "default")),
+		foundObjects(Parse(string(spec), "default", false)),
 	)
 }


### PR DESCRIPTION
The current behavior of helm-diff is to show diffs even when the YAML files are semantically identical but they contain style
differences, such as indentation or key ordering.

As an example, the following two YAMLs
```yaml
apiVersion: v1
kind: Service
metadata:
  name: app-name
  labels:
    app.kubernetes.io/name: app-name
    app.kubernetes.io/managed-by: Helm
spec:
  ports:
    - name: http
      port: 80
      targetPort: http
  selector:
    app.kubernetes.io/name: app-name
  type: ClusterIP
```
```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: app-name
  name: app-name
spec:
  ports:
  - name: http
    port: 80
    targetPort: http
  selector:
    app.kubernetes.io/name: app-name
  type: ClusterIP
```
would be showing the following diffs
```diff
  apiVersion: v1
  kind: Service
  metadata:
-   name: app-name
    labels:
-     app.kubernetes.io/name: app-name     
      app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: app-name
+   name: app-name
  spec:
    ports:
-     - name: http
-       port: 80
-       targetPort: http
+   - name: http
+     port: 80
+     targetPort: http
    selector:
      app.kubernetes.io/name: app-name
    type: ClusterIP
```
even though they are semantically the same.

This commit exploits the reordering and normalization that is performed by the yaml package when marshaling, by unmarshaling and re-marshaling all manifests before running the diff, thus eliminating the issue.
This PR should address and fix #257.