### PR TITLE
Added Source Installation Documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install: build
 	cp plugin.yaml $(HELM_HOME)/plugins/helm-diff/
 
 .PHONY: install/helm3
-install/helm3:
+install/helm3: build
 	mkdir -p $(HELM_3_PLUGINS)/helm-diff/bin
 	cp bin/diff $(HELM_3_PLUGINS)/helm-diff/bin
 	cp plugin.yaml $(HELM_3_PLUGINS)/helm-diff/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ E.g.
 curl -L $TARBALL_URL | tar -C $(helm home)/plugins -xzv
 ```
 
-
 ### From Source
 #### Prerequisites
  - GoLang `>= 1.14`
@@ -41,7 +40,6 @@ The first step is to download the repository and enter the directory. You can do
 Next, depending on which helm version you have, install the plugin into helm.
 
 ##### Helm 2
-
 ```bash
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ curl -L $TARBALL_URL | tar -C $(helm home)/plugins -xzv
 ```
 
 
+### From Source
+#### Prerequisites
+ - GoLang `>= 1.14`
+
+Make sure you do not have a verison of `helm-diff` installed. You can remove it by running `helm plugin uninstall diff`
+
+#### Installation Steps
+The first step is to download the repository and enter the directory. You can do this via `git clone` or downloaing and extracting the release. If you clone via git, remember to checkout the latest tag for the latest release.
+
+Next, depending on which helm version you have, install the plugin into helm.
+
+##### Helm 2
+
+```bash
+make install
+```
+
+##### Helm 3
+```bash
+make install/helm3
+```
+
+
 ## Usage
 
 ```


### PR DESCRIPTION
## Changes:
 - Added documentation to install from source (useful if no binaries are compatible)
 - Added a dependency on the `build` target in the Makefile's `install/helm3` target to allow one-line installation

Ref #275 