### PR TITLE
Ensure an initial separator is present in the yaml manifest

### DIFF
--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -84,6 +84,10 @@ func ParseRelease(release *release.Release, includeTests bool) map[string]*Mappi
 
 // Parse parses manifest strings into MappingResult
 func Parse(manifest string, defaultNamespace string, excludedHooks ...string) map[string]*MappingResult {
+	// Ensure we have an initial yaml separator
+	if manifest[0:4] != "---\n" {
+		manifest = "---\n" + manifest
+	}
 	// Ensure we have a newline in front of the yaml seperator
 	scanner := bufio.NewScanner(strings.NewReader("\n" + manifest))
 	scanner.Split(scanYamlSpecs)


### PR DESCRIPTION
The current parsing logic assumes that the manifest containing all resources will start with a yaml separator and therefore it
discards the first token when parsing. While this is the default helm behavior, custom postprocessing of the manifests could lead to the initial separator missing. Helm will still accept this, since the resulting manifest is still a valid yaml file, but the diff plugin will always discard the first resource in such case, showing it as a missing resource in the diff.

This commit adds an extra check to ensure the assumption of initial yaml separator is always valid, by adding it in case it is missing.