### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
If helm install is running on cygwin, an error occurred:

```
# Installed plugin: secrets
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 2: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 4: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 8: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 9: C:\hostedtoolcache\windows\helm\3.6.0\x64\windows-amd64\helm.exe: command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 10: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 12: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 17: $'\r': command not found
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 28: syntax error near unexpected token `$'{\r''
# D:\a\helm-secrets\helm-secrets\tests\.tmp\cache\CYGWIN_NT-10.0\helm\home\helm\plugins\helm-diff/install-binary.sh: line 28: `initArch() {
'
# Error: plugin install hook for "diff" exited with error
```

To prevent auto crlf on shell scripts, I added a .gitattributes file.

See also:
https://techblog.dorogin.com/case-of-windows-line-ending-in-bash-script-7236f056abe