### PR TITLE
Fix 'template' output not including resources with '.' in the name

### DIFF
--- a/diff/report.go
+++ b/diff/report.go
@@ -193,7 +193,7 @@ func setupTemplateReport(r *Report) {
 // report with template output will only have access to ReportTemplateSpec.
 // This function reverts parsedMetadata.String()
 func (t *ReportTemplateSpec) loadFromKey(key string) error {
-	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9-]+), (?P<kind>\w+) \((?P<api>[a-z0-9.]+)\)`)
+	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9-.]+), (?P<kind>\w+) \((?P<api>[a-z0-9.]+)\)`)
 	matches := pattern.FindStringSubmatch(key)
 	if len(matches) > 1 {
 		t.Namespace = matches[1]


### PR DESCRIPTION
Noticed the `json` and `template` output formats were missing changes for a few of our resources

Narrowed it down to these resources having `.`'s in their name and this not being selected by the key-parsing regex