### PR TITLE
Fix for Install-Binary script

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -148,7 +148,7 @@ func Releases(oldIndex, newIndex map[string]*manifest.MappingResult, suppressedK
 	return Manifests(oldIndex, newIndex, suppressedKinds, showSecrets, context, output, stripTrailingCR, to)
 }
 
-func diffMappingResults(oldContent *manifest.MappingResult, newContent *manifest.MappingResult, stripTrailingCR bool ) []difflib.DiffRecord {
+func diffMappingResults(oldContent *manifest.MappingResult, newContent *manifest.MappingResult, stripTrailingCR bool) []difflib.DiffRecord {
 	return diffStrings(oldContent.Content, newContent.Content, stripTrailingCR)
 }
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -7,11 +7,10 @@ PROJECT_GH="databus23/$PROJECT_NAME"
 export GREP_COLOR="never"
 
 [ -z "$HELM_BIN" ] && HELM_BIN=$(which helm)
-
 HELM_MAJOR_VERSION=$("${HELM_BIN}" version --client --short | awk -F '.' '{print $1}')
 
 HELM_HOME=$("${HELM_BIN}" home --debug=false)
-[ -z "$HELM_HOME" ] && HELM_HOME="$HOME/.helm"
+[ -z "$HELM_HOME" ] && HELM_HOME=$(helm env | grep 'HELM_DATA_HOME' | cut -d '=' -f2 | tr -d '"')
 
 mkdir -p "$HELM_HOME"
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -6,9 +6,16 @@ PROJECT_NAME="helm-diff"
 PROJECT_GH="databus23/$PROJECT_NAME"
 export GREP_COLOR="never"
 
+[ -z "$HELM_BIN" ] && HELM_BIN=$(which helm)
+
 HELM_MAJOR_VERSION=$("${HELM_BIN}" version --client --short | awk -F '.' '{print $1}')
 
-: ${HELM_PLUGIN_DIR:="$("${HELM_BIN}" home --debug=false)/plugins/helm-diff"}
+HELM_HOME=$("${HELM_BIN}" home --debug=false)
+[ -z "$HELM_HOME" ] && HELM_HOME="$HOME/.helm"
+
+mkdir -p "$HELM_HOME"
+
+: ${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/helm-diff"}
 
 # Convert the HELM_PLUGIN_DIR to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin
@@ -100,7 +107,7 @@ downloadFile() {
 installFile() {
   HELM_TMP="/tmp/$PROJECT_NAME"
   mkdir -p "$HELM_TMP"
-  tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
+  tar xvzf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
   HELM_TMP_BIN="$HELM_TMP/diff/bin/diff"
   echo "Preparing to install into ${HELM_PLUGIN_DIR}"
   mkdir -p "$HELM_PLUGIN_DIR/bin"


### PR DESCRIPTION
The script failed because of some conditions assumed true, fixed as follow:

* if HELM_BIN is not set the just uses helm path
* helm home command doesn't seem to exist on helm3.x, using a default path if this is the case
* tgz downloaded file wasn't extracted properly


resolves #244