### PR TITLE
feat: --find-renames for discovering renames based on content

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// AddDiffOptions adds flags for the various consolidated options to the functions in the diff package
 func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.BoolVar(&o.ShowSecrets, "show-secrets", false, "do not redact secret values in the output")
@@ -12,8 +13,10 @@ func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
+	f.Float32VarP(&o.FindRenames, "find-renames", "D", 0, "Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched")
 }
 
+// ProcessDiffOptions processes the set flags and handles possible interactions between them
 func ProcessDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	if q, _ := f.GetBool("suppress-secrets"); q {
 		o.SuppressedKinds = append(o.SuppressedKinds, "Secret")

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/databus23/helm-diff/v3/diff"
+	"github.com/spf13/pflag"
+)
+
+func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
+	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
+	f.BoolVar(&o.ShowSecrets, "show-secrets", false, "do not redact secret values in the output")
+	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
+	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
+	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
+}
+
+func ProcessDiffOptions(f *pflag.FlagSet, o *diff.Options) {
+	if q, _ := f.GetBool("suppress-secrets"); q {
+		o.SuppressedKinds = append(o.SuppressedKinds, "Secret")
+	}
+}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -117,7 +117,7 @@ func redactSecrets(old, new *manifest.MappingResult) {
 	if old != nil {
 		oldSecret.Data = nil
 		if err := serializer.Encode(&oldSecret, &buf); err != nil {
-
+			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
 		}
 		old.Content = getComment(old.Content) + strings.Replace(strings.Replace(buf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
 		buf.Reset() //reuse buffer for new secret
@@ -125,7 +125,7 @@ func redactSecrets(old, new *manifest.MappingResult) {
 	if new != nil {
 		newSecret.Data = nil
 		if err := serializer.Encode(&newSecret, &buf); err != nil {
-
+			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
 		}
 		new.Content = getComment(new.Content) + strings.Replace(strings.Replace(buf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
 	}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -210,7 +210,11 @@ func printDiffRecord(diff difflib.DiffRecord, to io.Writer) {
 	case difflib.LeftOnly:
 		fmt.Fprintf(to, "%s\n", ansi.Color("- "+text, "red"))
 	case difflib.Common:
-		fmt.Fprintf(to, "%s\n", "  "+text)
+		if text == "" {
+			fmt.Fprintln(to)
+		} else {
+			fmt.Fprintf(to, "%s\n", "  "+text)
+		}
 	}
 }
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -196,10 +196,10 @@ metadata:
 		}}
 
 	t.Run("OnChange", func(t *testing.T) {
-
 		var buf1 bytes.Buffer
+		diffOptions := Options{"diff", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "diff", false, &buf1); !changesSeen {
+		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
 		}
 
@@ -216,8 +216,9 @@ metadata:
 
 	t.Run("OnNoChange", func(t *testing.T) {
 		var buf2 bytes.Buffer
+		diffOptions := Options{"diff", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specRelease, specRelease, []string{}, true, 10, "diff", false, &buf2); changesSeen {
+		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 
@@ -225,10 +226,10 @@ metadata:
 	})
 
 	t.Run("OnChangeSimple", func(t *testing.T) {
-
 		var buf1 bytes.Buffer
+		diffOptions := Options{"simple", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "simple", false, &buf1); !changesSeen {
+		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
 		}
 
@@ -239,8 +240,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnNoChangeSimple", func(t *testing.T) {
 		var buf2 bytes.Buffer
-
-		if changesSeen := Manifests(specRelease, specRelease, []string{}, true, 10, "simple", false, &buf2); changesSeen {
+		diffOptions := Options{"simple", 10, false, true, []string{}}
+		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 
@@ -248,10 +249,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	})
 
 	t.Run("OnChangeTemplate", func(t *testing.T) {
-
 		var buf1 bytes.Buffer
+		diffOptions := Options{"template", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "template", false, &buf1); !changesSeen {
+		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
 		}
 
@@ -266,10 +267,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	})
 
 	t.Run("OnChangeJSON", func(t *testing.T) {
-
 		var buf1 bytes.Buffer
+		diffOptions := Options{"json", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "json", false, &buf1); !changesSeen {
+		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
 		}
 
@@ -285,8 +286,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
 		var buf2 bytes.Buffer
+		diffOptions := Options{"template", 10, false, true, []string{}}
 
-		if changesSeen := Manifests(specRelease, specRelease, []string{}, true, 10, "template", false, &buf2); changesSeen {
+		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 
@@ -296,7 +298,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		os.Setenv("HELM_DIFF_TPL", "testdata/customTemplate.tpl")
-		if changesSeen := Manifests(specBeta, specRelease, []string{}, true, 10, "template", false, &buf1); !changesSeen {
+		diffOptions := Options{"template", 10, false, true, []string{}}
+
+		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -204,13 +204,13 @@ metadata:
 		}
 
 		require.Equal(t, `default, nginx, Deployment (apps) has changed:
-  
+
 - apiVersion: apps/v1beta1
 + apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: nginx
-  
+
 `, buf1.String())
 	})
 


### PR DESCRIPTION
If we rename objects, they will appear as
add and remove actions, which makes it difficult
to assess the semantic delta, which may only be
a simple renaming.

The current implementation creates potentially
a diff between every add/remove item, which
means O(n^2) runtime. So it should only be
enabled if such changes are rare