### PR TITLE
Disable colors when TERM=dumb

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,10 @@ func New() *cobra.Command {
 			if nc, _ := cmd.Flags().GetBool("no-color"); nc {
 				ansi.DisableColors(true)
 			} else if !cmd.Flags().Changed("no-color") {
-				ansi.DisableColors(!terminal.IsTerminal(int(os.Stdout.Fd())))
+				term := terminal.IsTerminal(int(os.Stdout.Fd()))
+				// https://github.com/databus23/helm-diff/issues/281
+				dumb := os.Getenv("TERM") == "dumb"
+				ansi.DisableColors(!term || dumb)
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
See how it works by running `helm-diff` with or without setting the `TERM` value:

```
# This should color output if your terminal supports colors
HELM_NAMESPACE=default HELM_BIN=helm372 ./helm-diff upgrade envoy1 stable/envoy --three-way-merge

# Notice TERM=dumb- it should NOT color output
TERM=dumb HELM_NAMESPACE=default HELM_BIN=helm372 ./helm-diff upgrade envoy1 stable/envoy --three-way-merge
```

Fixes #281