### PR TITLE
Start using golang 1.17.5 to build release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 .PHONY: build
 build: lint
 	mkdir -p bin/
-	go build -i -v -o bin/diff -ldflags="$(LDFLAGS)"
+	go build -v -o bin/diff -ldflags="$(LDFLAGS)"
 
 .PHONY: test
 test:
@@ -53,7 +53,7 @@ docker-run-release: export pkg=/go/src/github.com/databus23/helm-diff
 docker-run-release:
 	git checkout master
 	git push
-	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.13.3 make bootstrap release
+	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.7.5 make bootstrap release
 
 .PHONY: dist
 dist: export COPYFILE_DISABLE=1 #teach OSX tar to not put ._* files in tar archive


### PR DESCRIPTION
docker-run-release was still building using golang 1.13.3. Should use 1.17 to match the rest of the project.