### PR TITLE
Migrate to GH actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+max_line_length = 120
+trim_trailing_whitespace = true
+shell_variant = posix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,132 @@
+---
+name: CI
+
+env:
+  VERSION_GO: '1.17.5'
+  VERSION_HELM: 'v3.7.0'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "Build & Test"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.VERSION_GO }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: make bootstrap
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Verify installation
+        run: |
+          mkdir -p helmhome
+          make install HELM_HOME=helmhome
+          helmhome/plugins/helm-diff/bin/diff version
+
+  helm-install:
+    name: helm install
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        shell: [ default ]
+        experimental: [ false ]
+        include:
+          - os: windows-latest
+            shell: wsl
+            experimental: false
+          - os: windows-latest
+            shell: cygwin
+            experimental: true
+    steps:
+      - name: Disable autocrlf
+        if: "contains(matrix.os, 'windows-latest')"
+        run: |-
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v2
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v1.1
+        with:
+          version: ${{ env.VERSION_HELM }}
+
+      - name: Setup WSL
+        if: "contains(matrix.shell, 'wsl')"
+        uses: Vampire/setup-wsl@v1
+
+      - name: Setup Cygwin
+        if: "contains(matrix.shell, 'cygwin')"
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+          platform: x64
+
+      - name: helm plugin install
+        run: helm plugin install .
+
+  integration-tests:
+    name: Integration Tests
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.11.1"
+
+      - uses: actions/checkout@v2
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v1.1
+        with:
+          version: ${{ env.VERSION_HELM }}
+
+      - name: helm plugin install
+        run: helm plugin install .
+
+      - name: helm create helm-diff
+        run: helm create helm-diff
+
+      - name: helm diff upgrade --install helm-diff ./helm-diff
+        run: helm diff upgrade --install helm-diff ./helm-diff
+
+      - name: helm upgrade -i helm-diff ./helm-diff
+        run: helm upgrade -i helm-diff ./helm-diff
+
+      - name: helm diff upgrade -C 3 --set replicaCount=2 --install helm-diff ./helm-diff
+        run: helm diff upgrade -C 3 --set replicaCount=2 --install helm-diff ./helm-diff
+
+  shell-lint:
+    name: Lint install-binary.sh
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: luizm/action-sh-checker@v0.3.0
+        with:
+          sh_checker_exclude: "scripts"
+          sh_checker_checkbashisms_enable: true

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ docker-run-release: export pkg=/go/src/github.com/databus23/helm-diff
 docker-run-release:
 	git checkout master
 	git push
-	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.7.5 make bootstrap release
+	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.17.5 make bootstrap release
 
 .PHONY: dist
 dist: export COPYFILE_DISABLE=1 #teach OSX tar to not put ._* files in tar archive


### PR DESCRIPTION
Hi,

i recently read

> It would be great if anyone could enahnce our CI workflow to cover cygwin (if it's possible).

- https://github.com/databus23/helm-diff/pull/287#issuecomment-1008224018

and thought I can re-design the CI workflow in general in form as a proposal.

The new CI based on Github Action. It covers all tasks from Circle CI +

* helm plugin install on MacOS and Windows (3 variants)
* integration tests against real kubernetes
* Linting the shell script `install-binary.sh` with [shellcheck](https://github.com/koalaman/shellcheck), [shfmt](https://github.com/mvdan/sh) and [checkbashisms](https://linux.die.net/man/1/checkbashisms). Covered by https://github.com/luizm/action-sh-checker

To gain a preview of the flow, take a look here: https://github.com/jkroepke/helm-diff/actions/runs/1673641310

Most parts of the CI workflow are copied from https://github.com/jkroepke/helm-secrets

As mention in the tests, the installation on cygwin is broken.