### PR TITLE
HELM_DIFF_THREE_WAY_MERGE=true to imply --three-way-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Examples:
   # See https://github.com/databus23/helm-diff/issues/253 for more information.
   HELM_DIFF_USE_UPGRADE_DRY_RUN=true helm diff upgarde my-release datadog/datadog
 
+  # Set HELM_DIFF_THREE_WAY_MERGE=true to
+  # enable the three-way-merge on diff.
+  # This is equivalent to specifying the --three-way-merge flag.
+  # Read the flag usage below for more information on --three-way-merge.
+  HELM_DIFF_THREE_WAY_MERGE=true helm diff upgarde my-release datadog/datadog
+
 Flags:
       --allow-unreleased             enables diffing of releases that are not yet deployed via Helm
   -a, --api-versions stringArray     Kubernetes api versions used for Capabilities.APIVersions


### PR DESCRIPTION
This adds a dedicated envvar to enable the three-way-merge diff added in #304. It should be useful when you are using helm-diff from another command or script and you dont have ability to specify the --three-way-merge flag without modifying the command/script but you cant due to various reasons.