### PR TITLE
helm-diff doesn't include values from stdin for helm3 version

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -120,7 +120,31 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 		flags = append(flags, "--set-string", stringValue)
 	}
 	for _, valueFile := range d.valueFiles {
-		flags = append(flags, "--values", valueFile)
+		if strings.TrimSpace(valueFile) == "-" {
+			bytes, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+
+			tmpfile, err := ioutil.TempFile("", "helm-diff-stdin-values")
+			if err != nil {
+				return nil, err
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write(bytes); err != nil {
+				tmpfile.Close()
+				return nil, err
+			}
+
+			if err := tmpfile.Close(); err != nil {
+				return nil, err
+			}
+
+			flags = append(flags, "--values", tmpfile.Name())
+		} else {
+			flags = append(flags, "--values", valueFile)
+		}
 	}
 	for _, fileValue := range d.fileValues {
 		flags = append(flags, "--set-file", fileValue)


### PR DESCRIPTION
Hi,
Unfortunately previous [PR](https://github.com/databus23/helm-diff/pull/272) was close as state, but this fix is still needed, so I've created a new one. Please review it once you have time. thanks!

There is an issue in helm-diff for helm3 version, it doesn't include values from stdin. For helm2 it works as expected.

```
$ cat values-10.yaml                                                               
lolkek:                                                                            
  helloword: test                                                                  
  new:                                                                             
    ohoho:                                                                         
      values-10: lolodddd10 
```
                                          
Current behavior:
```                                
$ cat values-10.yaml | helm3 diff upgrade test_helm . --allow-unreleased --values -
                                                                         
+ # Source: test_helm/templates/configMap.yaml                                     
+ apiVersion: v1                                                                   
+ kind: ConfigMap                                                                  
+ metadata:                                                                        
+   name: game-demo                                                                
+ data:                                                                            
+   user-interface.properties: |                                                   
+     null         
```
Expected behavior with applied fix:

```
$ cat values-10.yaml | helm3 diff upgrade test_helm . --allow-unreleased --values -
                                                                                 
+ # Source: test_helm/templates/configMap.yaml                                     
+ apiVersion: v1                                                                   
+ kind: ConfigMap                                                                  
+ metadata:                                                                        
+   name: game-demo                                                                
+ data:                                                                            
+   user-interface.properties: |                                                   
+     ohoho:
```