### PR TITLE
Add Alpine Linux target to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     needs: [build]
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -59,7 +60,12 @@ jobs:
             experimental: false
           - os: windows-latest
             shell: cygwin
-            experimental: true
+            experimental: false
+          - os: ubuntu-latest
+            container: alpine
+            shell: sh
+            experimental: false
+
     steps:
       - name: Disable autocrlf
         if: "contains(matrix.os, 'windows-latest')"


### PR DESCRIPTION
I have added alpine as a install target in the test matrix.
Alpine also uses busybox, so not sure if it needed to add a separate busybox target or if this is enough.

Fixes #347