### PR TITLE
Annotation to override object name for diff purposes

### DIFF
--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
@@ -40,8 +40,13 @@ func (m metadata) String() string {
 	if len(sp) > 1 {
 		apiBase = strings.Join(sp[:len(sp)-1], "/")
 	}
-
-	return fmt.Sprintf("%s, %s, %s (%s)", m.Metadata.Namespace, m.Metadata.Name, m.Kind, apiBase)
+	name := m.Metadata.Name
+	if a := m.Metadata.Annotations; a != nil {
+		if baseName, ok := a["helm-diff/base-name"]; ok {
+			name = baseName
+		}
+	}
+	return fmt.Sprintf("%s, %s, %s (%s)", m.Metadata.Namespace, name, m.Kind, apiBase)
 }
 
 func scanYamlSpecs(data []byte, atEOF bool) (advance int, token []byte, err error) {

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -101,3 +101,13 @@ func TestEmpty(t *testing.T) {
 		foundObjects(Parse(string(spec), "default", false)),
 	)
 }
+
+func TestBaseNameAnnotation(t *testing.T) {
+	spec, err := ioutil.ReadFile("testdata/secret_immutable.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{"default, bat-secret, Secret (v1)"},
+		foundObjects(Parse(string(spec), "default", false)),
+	)
+}

--- a/manifest/testdata/secret_immutable.yaml
+++ b/manifest/testdata/secret_immutable.yaml
@@ -1,0 +1,14 @@
+
+---
+# Source: nginx/some-secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bat-secret-ab1234cd
+  annotations:
+    helm-diff/base-name: bat-secret
+immutable: true
+type: Opaque
+stringData:
+  secret1: Very secretive secret
+  secret2: One more


### PR DESCRIPTION
This is useful for immutable secrets which are typically named as secret-base-name-<.data hash>. Previously old and new secrets were considere completely independent ConfigMap/Secret. With this annotation user can add "helm.sh/base-name: secret-base-name" annotation and compare old and new objects similar to git rename.

#378 