### PR TITLE
diff/report: fix key regexp

### DIFF
--- a/diff/report.go
+++ b/diff/report.go
@@ -191,7 +191,7 @@ func setupTemplateReport(r *Report) {
 // report with template output will only have access to ReportTemplateSpec.
 // This function reverts parsedMetadata.String()
 func (t *ReportTemplateSpec) loadFromKey(key string) error {
-	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9-]+), (?P<kind>\w+) \((?P<api>[a-z0-9.]+)\)`)
+	pattern := regexp.MustCompile(`(?P<namespace>[a-z0-9-]+), (?P<name>[a-z0-9.-]+), (?P<kind>\w+) \((?P<api>[^)]+)\)`)
 	matches := pattern.FindStringSubmatch(key)
 	if len(matches) > 1 {
 		t.Namespace = matches[1]

--- a/diff/report_test.go
+++ b/diff/report_test.go
@@ -1,0 +1,36 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromKey(t *testing.T) {
+	keyToReportTemplateSpec := map[string]ReportTemplateSpec{
+		"default, nginx, Deployment (apps)": {
+			Namespace: "default",
+			Name:      "nginx",
+			Kind:      "Deployment",
+			API:       "apps",
+		},
+		"default, probes.monitoring.coreos.com, CustomResourceDefinition (apiextensions.k8s.io)": {
+			Namespace: "default",
+			Name:      "probes.monitoring.coreos.com",
+			Kind:      "CustomResourceDefinition",
+			API:       "apiextensions.k8s.io",
+		},
+		"default, my-cert, Certificate (cert-manager.io/v1)": {
+			Namespace: "default",
+			Name:      "my-cert",
+			Kind:      "Certificate",
+			API:       "cert-manager.io/v1",
+		},
+	}
+
+	for key, expectedTemplateSpec := range keyToReportTemplateSpec {
+		templateSpec := &ReportTemplateSpec{}
+		require.NoError(t, templateSpec.loadFromKey(key))
+		require.Equal(t, expectedTemplateSpec, *templateSpec)
+	}
+}


### PR DESCRIPTION
The current regexp doesn't match all possible apis, for example
`cert-manager.io`.

As there is a closing `)` we can simply take everything before it.

Also resource names can have . in their name.