### PR TITLE
chore: Added support for setting --kube-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Flags:
   -h, --help                         help for diff
       --include-tests                enable the diffing of the helm test hooks
       --install                      enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match "helm upgrade --install" command
+      --kube-version string          Kubernetes version used for Capabilities.KubeVersion
       --kubeconfig string            This flag is ignored, to allow passing of this top level flag to helm
       --no-color                     remove colors from the output. If both --no-color and --color are unspecified, coloring enabled only when the stdout is a term and TERM is not "dumb"
       --no-hooks                     disable diffing of hooks
@@ -168,6 +169,7 @@ Flags:
   -h, --help                         help for upgrade
       --include-tests                enable the diffing of the helm test hooks
       --install                      enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match "helm upgrade --install" command
+      --kube-version string          Kubernetes version used for Capabilities.KubeVersion
       --kubeconfig string            This flag is ignored, to allow passing of this top level flag to helm
       --no-hooks                     disable diffing of hooks
       --normalize-manifests          normalize manifests before running diff to exclude style differences from the output

--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -192,6 +192,10 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 			flags = append(flags, "--api-versions", a)
 		}
 
+		if d.kubeVersion != "" {
+			flags = append(flags, "--kube-version", d.kubeVersion)
+		}
+
 		subcmd = "template"
 
 		filter = func(s []byte) []byte {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -56,6 +56,7 @@ type diffCmd struct {
 	normalizeManifests       bool
 	threeWayMerge            bool
 	extraAPIs                []string
+	kubeVersion              string
 	useUpgradeDryRun         bool
 	diff.Options
 }
@@ -157,6 +158,8 @@ func newChartCommand() *cobra.Command {
 	// - https://github.com/helm/helm/blob/d9ffe37d371c9d06448c55c852c800051830e49a/cmd/helm/template.go#L184
 	// - https://github.com/databus23/helm-diff/issues/318
 	f.StringArrayVarP(&diff.extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
+	// Support for kube-version was re-enabled and ported from helm2 to helm3 on https://github.com/helm/helm/pull/9040
+	f.StringVar(&diff.kubeVersion, "kube-version", "", "Kubernetes version used for Capabilities.KubeVersion")
 	f.VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
 	f.StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&diff.stringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")


### PR DESCRIPTION
Support for `--kube-version` was ported to Helm 3 on https://github.com/helm/helm/pull/9040.

I'm using `helm-diff` as a mechanism to determine if a PR will cause changes on installed releases. Then, depending on the result, I trigger pipelines dynamically targeting only the affected releases. Currently, not all the clusters share the same Kubernetes version, so being able to use this Helm 3 feature on Helm diff will improve a lot my workflow.
