### PR TITLE
Added bzip2 to build docker. Updated golang image and github-release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-run-release: export pkg=/go/src/github.com/databus23/helm-diff
 docker-run-release:
 	git checkout master
 	git push
-	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.17.5 make bootstrap release
+	docker run -it --rm -e GITHUB_TOKEN -v $(shell pwd):$(pkg) -w $(pkg) golang:1.18.1 make bootstrap release
 
 .PHONY: dist
 dist: export COPYFILE_DISABLE=1 #teach OSX tar to not put ._* files in tar archive

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -x
+apt-get update
+apt-get install bzip2
 
 if [ ! -f bin/github-release ]; then
   OS=$(uname)
-  curl -L https://github.com/aktau/github-release/releases/download/v0.7.2/$OS-amd64-github-release.tar.bz2 | tar -C bin/ -jvx --strip-components=3
+  mkdir -p bin
+  curl -L https://github.com/aktau/github-release/releases/download/v0.10.0/$OS-amd64-github-release.bz2 | bzcat >bin/github-release
+  chmod +x bin/github-release
 fi
 
 user=databus23


### PR DESCRIPTION
Golang image was missing bzip2 so github-release binary didn't install
and release docker didn't work.