### PR TITLE
feat(secrets): allow diffing stringData sections of secrets as well as data sections

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -3,7 +3,7 @@
 # Shamelessly copied from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-diff"
-PROJECT_GH="philomory/$PROJECT_NAME"
+PROJECT_GH="databus23/$PROJECT_NAME"
 export GREP_COLOR="never"
 
 # Convert HELM_BIN and HELM_PLUGIN_DIR to unix if cygpath is


### PR DESCRIPTION
Fixes #302.

If the same key appears in both the `data` and `stringData` sections of the same secret, the one in the `stringData` section is the one considered, because [that is how Kubernetes itself behaves](https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data).