### PR TITLE
Fix for M1 laptops returning arm64 for uname -m.

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -42,6 +42,7 @@ initArch() {
   armv5*) ARCH="armv5" ;;
   armv6*) ARCH="armv6" ;;
   armv7*) ARCH="armv7" ;;
+  arm64) ARCH="arm64" ;;
   aarch64) ARCH="arm64" ;;
   x86) ARCH="386" ;;
   x86_64) ARCH="amd64" ;;


### PR DESCRIPTION
My M1 MBP returns arm64 for `uname -m`.