### PR TITLE
diff: fix secret redaction for secrets with stringData

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -169,6 +169,8 @@ func assertDiff(t *testing.T, before, after string, context int, stripTrailingCR
 }
 
 func TestManifests(t *testing.T) {
+	ansi.DisableColors(true)
+
 	specBeta := map[string]*manifest.MappingResult{
 		"default, nginx, Deployment (apps)": {
 


### PR DESCRIPTION
Fixes #302.

This is an improved version of #393, with the following changes:

- The rewrite from `stringData` to `data` does not do an incorrect second Base64 encoding (the Base64 encoding is handled within k8s/client-go during YAML marshalling). For reference, [this is the equivalent code in the k8s apiserver](https://github.com/kubernetes/kubernetes/blob/2dba4034f8424574c42cebfce91664c4b7e08c61/pkg/apis/core/v1/conversion.go#L395-L403).
- Tests have been added that demonstrate diffing of redacted secrets with either `data` or `stringData` sections.