### PR TITLE
Check the error returned by genManifest

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -257,6 +257,9 @@ func (d *diffCmd) runHelm3() error {
 			return errors.Wrap(err, "unable to build kubernetes objects from new release manifest")
 		}
 		releaseManifest, installManifest, err = genManifest(original, target)
+		if err != nil {
+			return errors.Wrap(err, "unable to generate manifests")
+		}
 	}
 
 	currentSpecs := make(map[string]*manifest.MappingResult)


### PR DESCRIPTION
Check the error returned by genManifest function when three way merge is performed. This fixes the cases when chart produces incorrect manifest (for example a Deployment without image in initContainers):
```
...
initContainers:
  - name: nginx-init
...
```
Currently manifest with an error is just being dropped from comparison and appears as being removed in the diff:
```
$ helm diff upgrade dummy . --three-way-merge

default, dummy, Deployment (apps) has been removed:
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-   creationTimestamp: "2022-10-21T08:22:50Z"
-   labels:
-     app.kubernetes.io/instance: dummy
-     app.kubernetes.io/managed-by: Helm
...
```

Now with the fix it will display the proper error:
```
Error: unable to generate manifests: cannot patch "dummy" with kind Deployment: Deployment.apps "dummy" is invalid: spec.template.spec.initContainers[0].image: Required value
Error: plugin "diff" exited with error
```