### PR TITLE
Skip `helm get hooks` when `--three-way-merge=true`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HELM_HOME ?= $(shell helm home)
 VERSION := $(shell sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' plugin.yaml)
 
-HELM_3_PLUGINS := $(shell bash -c 'eval $$(helm env); echo $$HELM_PLUGINS')
+HELM_3_PLUGINS := $(shell helm env HELM_PLUGINS)
 
 PKG:= github.com/databus23/helm-diff/v3
 LDFLAGS := -X $(PKG)/cmd.Version=$(VERSION)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -261,7 +261,7 @@ func (d *diffCmd) runHelm3() error {
 
 	currentSpecs := make(map[string]*manifest.MappingResult)
 	if !newInstall && !d.dryRun {
-		if !d.noHooks {
+		if !d.noHooks && !d.threeWayMerge {
 			hooks, err := getHooks(d.release, d.namespace)
 			if err != nil {
 				return err


### PR DESCRIPTION
Hooks manifests would have been already added when `--three-way-merge=true` (by `genManifest` function). Unless `--no-hooks=true` have been supplied as well - making them being skipped earlier as well.

This results into only one case when hooks manifests should be added separately: `--three-way-merge=false --no-hooks=false` (the current defaults).

With the current code however, when charts contain hooks and `--three-way-merge=true`, some confusing output is returned (esp. on empty diff). That's because hooks manifests are added twice: first inside `genManifest` function, and then again by appending results of `getHooks` function.

```console
$ helm diff upgrade my-release my-chart --values values.yaml --three-way-merge=true
2022/12/01 16:52:34 Error: Found duplicate key "my-ns, my-cm, ConfigMap (v1)" in manifest
```

The exit code is `0`, though. A user thinking could be:
- Did `helm diff` fail, but did not reflect that in exit code?
- It did not fail, but because of the `Error` it could have missed diffing at all?
- Why the diff is empty - because of the `Error` or is it empty indeed?

Perhaps, replacing `Error` with `Warning` in [the message](https://github.com/databus23/helm-diff/blob/c5d10a3e91f4ac3882eec23b7b35871eaeb9e895/manifest/parse.go#L117) would make sense as well.