### PR TITLE
Fix for #430 With Helm 3 the release names are namespace scoped, thus it should be possible to helm diff release of two release with same name in different namespaces

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -22,7 +22,8 @@ type release struct {
 }
 
 const releaseCmdLongUsage = `
-This command compares the manifests details of a different releases created from the same chart
+This command compares the manifests details of a different releases created from the same chart.
+The release name may be specified using namespace/release syntax.
 
 It can be used to compare the manifests of
 
@@ -30,6 +31,7 @@ It can be used to compare the manifests of
 	$ helm diff release [flags] release1 release2
    Example:
 	$ helm diff release my-prod my-stage
+	$ helm diff release prod/my-prod stage/my-stage
 `
 
 func releaseCmd() *cobra.Command {
@@ -83,25 +85,38 @@ func releaseCmd() *cobra.Command {
 }
 
 func (d *release) differentiateHelm3() error {
-	namespace := os.Getenv("HELM_NAMESPACE")
 	excludes := []string{helm3TestHook, helm2TestSuccessHook}
 	if d.includeTests {
 		excludes = []string{}
 	}
-	releaseResponse1, err := getRelease(d.releases[0], namespace)
+
+	namespace := os.Getenv("HELM_NAMESPACE")
+
+	release1 = d.releases[0];
+	if strings.Contains(release1) {
+		namespace = release1.Split("/")[0]
+		release1 = release1.Split("/")[1]
+	}
+	releaseResponse1, err := getRelease(release1, namespace)
 	if err != nil {
 		return err
 	}
-	releaseChart1, err := getChart(d.releases[0], namespace)
+	releaseChart1, err := getChart(release1, namespace)
 	if err != nil {
 		return err
 	}
 
-	releaseResponse2, err := getRelease(d.releases[1], namespace)
+	namespace := os.Getenv("HELM_NAMESPACE")
+	release2 = d.releases[1];
+	if strings.Contains(release2) {
+		namespace = release2.Split("/")[0]
+		release2 = release2.Split("/")[1]
+	}
+	releaseResponse2, err := getRelease(release2, namespace)
 	if err != nil {
 		return err
 	}
-	releaseChart2, err := getChart(d.releases[1], namespace)
+	releaseChart2, err := getChart(release2, namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -92,7 +92,7 @@ func (d *release) differentiateHelm3() error {
 
 	namespace1 := os.Getenv("HELM_NAMESPACE")
 	release1 := d.releases[0];
-	if strings.Contains(release1) {
+	if release1.Contains("/") {
 		namespace1 = release1.Split("/")[0]
 		release1 = release1.Split("/")[1]
 	}
@@ -107,7 +107,7 @@ func (d *release) differentiateHelm3() error {
 
 	namespace2 := os.Getenv("HELM_NAMESPACE")
 	release2 := d.releases[1];
-	if strings.Contains(release2) {
+	if release2.Contains("/") {
 		namespace2 = release2.Split("/")[0]
 		release2 = release2.Split("/")[1]
 	}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -90,33 +90,32 @@ func (d *release) differentiateHelm3() error {
 		excludes = []string{}
 	}
 
-	namespace := os.Getenv("HELM_NAMESPACE")
-
-	release1 = d.releases[0];
+	namespace1 := os.Getenv("HELM_NAMESPACE")
+	release1 := d.releases[0];
 	if strings.Contains(release1) {
-		namespace = release1.Split("/")[0]
+		namespace1 = release1.Split("/")[0]
 		release1 = release1.Split("/")[1]
 	}
-	releaseResponse1, err := getRelease(release1, namespace)
+	releaseResponse1, err := getRelease(release1, namespace1)
 	if err != nil {
 		return err
 	}
-	releaseChart1, err := getChart(release1, namespace)
+	releaseChart1, err := getChart(release1, namespace1)
 	if err != nil {
 		return err
 	}
 
-	namespace := os.Getenv("HELM_NAMESPACE")
-	release2 = d.releases[1];
+	namespace2 := os.Getenv("HELM_NAMESPACE")
+	release2 := d.releases[1];
 	if strings.Contains(release2) {
-		namespace = release2.Split("/")[0]
+		namespace2 = release2.Split("/")[0]
 		release2 = release2.Split("/")[1]
 	}
-	releaseResponse2, err := getRelease(release2, namespace)
+	releaseResponse2, err := getRelease(release2, namespace2)
 	if err != nil {
 		return err
 	}
-	releaseChart2, err := getChart(release2, namespace)
+	releaseChart2, err := getChart(release2, namespace2)
 	if err != nil {
 		return err
 	}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -123,8 +123,8 @@ func (d *release) differentiateHelm3() error {
 
 	if releaseChart1 == releaseChart2 {
 		seenAnyChanges := diff.Releases(
-			manifest.Parse(string(releaseResponse1), namespace, d.normalizeManifests, excludes...),
-			manifest.Parse(string(releaseResponse2), namespace, d.normalizeManifests, excludes...),
+			manifest.Parse(string(releaseResponse1), namespace1, d.normalizeManifests, excludes...),
+			manifest.Parse(string(releaseResponse2), namespace2, d.normalizeManifests, excludes...),
 			&d.Options,
 			os.Stdout)
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/helm/pkg/helm"
@@ -92,9 +93,9 @@ func (d *release) differentiateHelm3() error {
 
 	namespace1 := os.Getenv("HELM_NAMESPACE")
 	release1 := d.releases[0];
-	if release1.Contains("/") {
-		namespace1 = release1.Split("/")[0]
-		release1 = release1.Split("/")[1]
+	if strings.Contains(release1, "/") {
+		namespace1 = strings.Split(release1, "/")[0]
+		release1 = strings.Split(release1, "/")[1]
 	}
 	releaseResponse1, err := getRelease(release1, namespace1)
 	if err != nil {
@@ -107,9 +108,9 @@ func (d *release) differentiateHelm3() error {
 
 	namespace2 := os.Getenv("HELM_NAMESPACE")
 	release2 := d.releases[1];
-	if release2.Contains("/") {
-		namespace2 = release2.Split("/")[0]
-		release2 = release2.Split("/")[1]
+	if strings.Contains(release2, "/") {
+		namespace2 = strings.Split(release2, "/")[0]
+		release2 = strings.Split(release2, "/")[1]
 	}
 	releaseResponse2, err := getRelease(release2, namespace2)
 	if err != nil {


### PR DESCRIPTION
Support syntax:

> helm diff release [namespace1/]release1 [namespace2/]release2

Resolves #430