### PR TITLE
Add support for --insecure-skip-tls-verify

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -105,6 +105,9 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	for _, arg := range d.postRendererArgs {
 		flags = append(flags, "--post-renderer-args", arg)
 	}
+	if d.insecureSkipTLSVerify {
+		flags = append(flags, "--insecure-skip-tls-verify")
+	}
 	// Helm automatically enable --reuse-values when there's no --set, --set-string, --set-values, --set-file present.
 	// Let's simulate that in helm-diff.
 	// See https://medium.com/@kcatstack/understand-helm-upgrade-flags-reset-values-reuse-values-6e58ac8f127e

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -52,6 +52,7 @@ type diffCmd struct {
 	includeTests             bool
 	postRenderer             string
 	postRendererArgs         []string
+	insecureSkipTLSVerify    bool
 	install                  bool
 	normalizeManifests       bool
 	threeWayMerge            bool
@@ -197,6 +198,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.dryRun, "dry-run", false, "disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation")
 	f.StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
 	f.StringArrayVar(&diff.postRendererArgs, "post-renderer-args", []string{}, "an argument to the post-renderer (can specify multiple)")
+	f.BoolVar(&diff.insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
 	f.BoolVar(&diff.normalizeManifests, "normalize-manifests", false, "normalize manifests before running diff to exclude style differences from the output")
 
 	AddDiffOptions(f, &diff.Options)


### PR DESCRIPTION
I believe helm-diff should eventually support all the helm-template flags including connection-related ones, so that helm-diff can be used in place where helm-template or helm-upgrade-dry-run to provide diff/dry-run functionality to existing script/program/etc.

This adds support for --insecure-skip-tls which is used to disable server verification on chart download.