### PR TITLE
feat: Allow suppressing annotations and labels

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -9,7 +9,9 @@ import (
 func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.BoolVar(&o.ShowSecrets, "show-secrets", false, "do not redact secret values in the output")
-	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
+	f.StringArrayVar(&o.SuppressedAnnotations, "suppress-annotation", []string{}, "allows suppression of the specified annotations in the diff output")
+	f.StringArrayVar(&o.SuppressedLabels, "suppress-label", []string{}, "allows suppression of the specified labels in the diff output")
+	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the kinds listed in the diff output")
 	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template, dyff. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")


### PR DESCRIPTION
Allows suppressing annotations and labels in the diff output.

Fixes #390.

Useful to ignore changes that might not make an helm upgrade worthwhile, such as  chart version labels.
Also allows hiding labels containing sensitive information, such as `kubectl.kubernetes.io/last-applied-configuration` on secrets when using three-way-merge.

It currently doesn't handle pod templates in deployments, etc. which could still be very useful (to hide checksum annotation changes, for example).