### PR TITLE
feat: Allow suppress diff line output by regex

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -15,6 +15,7 @@ func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template, dyff. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 	f.Float32VarP(&o.FindRenames, "find-renames", "D", 0, "Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched")
+	f.StringArrayVar(&o.SuppressedOutputLineRegex, "suppress-output-line-regex", []string{}, "a regex to suppress diff output lines that match")
 }
 
 // ProcessDiffOptions processes the set flags and handles possible interactions between them

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -79,7 +79,7 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, options *O
 }
 
 func doSuppress(report Report, suppressedOutputLineRegex []string) (Report, error) {
-	if len(suppressedOutputLineRegex) == 0 {
+	if len(report.entries) == 0 || len(suppressedOutputLineRegex) == 0 {
 		return report, nil
 	}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -85,19 +85,15 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, options *O
 		for _, entry := range report.entries {
 			var diffs []difflib.DiffRecord
 
+		DIFFS:
 			for _, diff := range entry.diffs {
-				matched := false
-
 				for _, suppressOutputRegex := range suppressOutputRegexes {
 					if suppressOutputRegex.MatchString(diff.Payload) {
-						matched = true
-						break
+						continue DIFFS
 					}
 				}
 
-				if !matched {
-					diffs = append(diffs, diff)
-				}
+				diffs = append(diffs, diff)
 			}
 
 			containsDiff := false

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -66,14 +66,14 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, options *O
 		doDiff(&report, key, nil, newContent, options)
 	}
 
-	filteredReport, err := doSuppress(report, options.SuppressedOutputLineRegex)
+	seenAnyChanges := len(report.entries) > 0
+
+	report, err := doSuppress(report, options.SuppressedOutputLineRegex)
 	if err != nil {
 		panic(err)
 	}
 
-	seenAnyChanges := len(report.entries) > 0
-	filteredReport.print(to)
-	filteredReport.clean()
+	report.print(to)
 	report.clean()
 	return seenAnyChanges
 }

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -100,12 +100,20 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, options *O
 				}
 			}
 
+			containsDiff := false
+
 			// Add entry to the report, if diffs are present.
 			for _, diff := range diffs {
 				if diff.Delta.String() != " " {
-					filteredReport.addEntry(entry.key, entry.suppressedKinds, entry.kind, entry.context, diffs, entry.changeType)
+					containsDiff = true
 					break
 				}
+			}
+
+			if containsDiff {
+				filteredReport.addEntry(entry.key, entry.suppressedKinds, entry.kind, entry.context, diffs, entry.changeType)
+			} else {
+				filteredReport.addEntry(entry.key, entry.suppressedKinds, entry.kind, entry.context, []difflib.DiffRecord{}, entry.changeType)
 			}
 		}
 	} else {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -285,7 +285,8 @@ spec:
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
 		}
 
-		require.Equal(t, ``, buf1.String())
+		require.Equal(t, `default, nginx, Deployment (apps) has changed:
+`, buf1.String())
 	})
 
 	t.Run("OnChangeRename", func(t *testing.T) {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -260,7 +260,7 @@ spec:
 
 	t.Run("OnChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -279,7 +279,7 @@ spec:
 
 	t.Run("OnChangeRename", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamed, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -300,7 +300,7 @@ spec:
 
 	t.Run("OnChangeRenameAndUpdate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndUpdated, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -322,7 +322,7 @@ spec:
 
 	t.Run("OnChangeRenameAndAdded", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -346,7 +346,7 @@ spec:
 
 	t.Run("OnChangeRenameAndRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -370,7 +370,7 @@ spec:
 
 	t.Run("OnNoChange", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -381,7 +381,7 @@ spec:
 
 	t.Run("OnChangeSimple", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -394,7 +394,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnNoChangeSimple", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0, []string{}}
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
@@ -404,7 +404,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnChangeTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -422,7 +422,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnChangeJSON", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"json", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"json", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -440,7 +440,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -452,7 +452,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		os.Setenv("HELM_DIFF_TPL", "testdata/customTemplate.tpl")
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0}
+		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -535,7 +535,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithByteData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithByteData, specSecretWithByteDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -560,7 +560,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithStringData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithStringData, specSecretWithStringDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")


### PR DESCRIPTION
This PR allow to suppress the diff report by using regex.
This option is more designed for power users and give them full control about the output.

There is a new diff option `--suppress-output-line-regex`  which can be applied multiple time.

If a line from the report matches the regex, the line gets removed from the report. If the diff entry has no deltas, the whole diffEntry (file) gets removed, except the headline `default, nginx, Deployment (apps) has changed:`

Since `--suppress-output-line-regex` applied only to the output of an diff, the behavior of `--detailed-exit-code` is not touch. If there are differences which are suppressed, the exit code remains still 2.

Feature in action:

<details>
<summary>helm diff upgrade prometheus-node-exporter prometheus-community/prometheus-node-exporter --version 4.18.0</summary>


```diff
default, prometheus-node-exporter, DaemonSet (apps) has changed:
  # Source: prometheus-node-exporter/templates/daemonset.yaml
  apiVersion: apps/v1
  kind: DaemonSet
  metadata:
    name: prometheus-node-exporter
    namespace: default
    labels:
-     helm.sh/chart: prometheus-node-exporter-4.17.0
+     helm.sh/chart: prometheus-node-exporter-4.18.0
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: metrics
      app.kubernetes.io/part-of: prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
-     app.kubernetes.io/version: "1.5.0"
+     app.kubernetes.io/version: "1.6.0"
  spec:
    selector:
      matchLabels:
        app.kubernetes.io/name: prometheus-node-exporter
        app.kubernetes.io/instance: prometheus-node-exporter
    updateStrategy:
      rollingUpdate:
        maxUnavailable: 1
      type: RollingUpdate
    template:
      metadata:
        annotations:
          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
        labels:
-         helm.sh/chart: prometheus-node-exporter-4.17.0
+         helm.sh/chart: prometheus-node-exporter-4.18.0
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/component: metrics
          app.kubernetes.io/part-of: prometheus-node-exporter
          app.kubernetes.io/name: prometheus-node-exporter
          app.kubernetes.io/instance: prometheus-node-exporter
-         app.kubernetes.io/version: "1.5.0"
+         app.kubernetes.io/version: "1.6.0"
      spec:
        automountServiceAccountToken: false
        securityContext:
          fsGroup: 65534
          runAsGroup: 65534
          runAsNonRoot: true
          runAsUser: 65534
        serviceAccountName: prometheus-node-exporter
        containers:
          - name: node-exporter
-           image: quay.io/prometheus/node-exporter:v1.5.0
+           image: quay.io/prometheus/node-exporter:v1.6.0
            imagePullPolicy: IfNotPresent
            args:
              - --path.procfs=/host/proc
              - --path.sysfs=/host/sys
              - --path.rootfs=/host/root
              - --path.udev.data=/host/root/run/udev/data
              - --web.listen-address=[$(HOST_IP)]:9100
            securityContext:
              readOnlyRootFilesystem: true
            env:
              - name: HOST_IP
                value: 0.0.0.0
            ports:
              - name: metrics
                containerPort: 9100
                protocol: TCP
            livenessProbe:
              failureThreshold: 3
              httpGet:
                httpHeaders:
                path: /
                port: 9100
                scheme: HTTP
              initialDelaySeconds: 0
              periodSeconds: 10
              successThreshold: 1
              timeoutSeconds: 1
            readinessProbe:
              failureThreshold: 3
              httpGet:
                httpHeaders:
                path: /
                port: 9100
                scheme: HTTP
              initialDelaySeconds: 0
              periodSeconds: 10
              successThreshold: 1
              timeoutSeconds: 1
            volumeMounts:
              - name: proc
                mountPath: /host/proc
                readOnly:  true
              - name: sys
                mountPath: /host/sys
                readOnly: true
              - name: root
                mountPath: /host/root
                mountPropagation: HostToContainer
                readOnly: true
        hostNetwork: true
        hostPID: true
+       nodeSelector:
+         kubernetes.io/os: linux
        tolerations:
          - effect: NoSchedule
            operator: Exists
        volumes:
          - name: proc
            hostPath:
              path: /proc
          - name: sys
            hostPath:
              path: /sys
          - name: root
            hostPath:
              path: /
default, prometheus-node-exporter, Service (v1) has changed:
  # Source: prometheus-node-exporter/templates/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: prometheus-node-exporter
    namespace: default
    labels:
-     helm.sh/chart: prometheus-node-exporter-4.17.0
+     helm.sh/chart: prometheus-node-exporter-4.18.0
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: metrics
      app.kubernetes.io/part-of: prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
-     app.kubernetes.io/version: "1.5.0"
+     app.kubernetes.io/version: "1.6.0"
    annotations:
+     prometheus.io/scrape: "true"
      prometheus.io/scrape: "true"
  spec:
    type: ClusterIP
    ports:
      - port: 9100
        targetPort: 9100
        protocol: TCP
        name: metrics
    selector:
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
default, prometheus-node-exporter, ServiceAccount (v1) has changed:
  # Source: prometheus-node-exporter/templates/serviceaccount.yaml
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: prometheus-node-exporter
    namespace: default
    labels:
-     helm.sh/chart: prometheus-node-exporter-4.17.0
+     helm.sh/chart: prometheus-node-exporter-4.18.0
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: metrics
      app.kubernetes.io/part-of: prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
-     app.kubernetes.io/version: "1.5.0"
+     app.kubernetes.io/version: "1.6.0"
```

</details>
<details>
<summary>helm diff upgrade prometheus-node-exporter prometheus-community/prometheus-node-exporter --version 4.18.0 --suppress-output-line-regex "helm.sh/chart" --suppress-output-line-regex "version"</summary>

```diff
default, prometheus-node-exporter, DaemonSet (apps) has changed:
  # Source: prometheus-node-exporter/templates/daemonset.yaml
  apiVersion: apps/v1
  kind: DaemonSet
  metadata:
    name: prometheus-node-exporter
    namespace: default
    labels:
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: metrics
      app.kubernetes.io/part-of: prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
  spec:
    selector:
      matchLabels:
        app.kubernetes.io/name: prometheus-node-exporter
        app.kubernetes.io/instance: prometheus-node-exporter
    updateStrategy:
      rollingUpdate:
        maxUnavailable: 1
      type: RollingUpdate
    template:
      metadata:
        annotations:
          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
        labels:
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/component: metrics
          app.kubernetes.io/part-of: prometheus-node-exporter
          app.kubernetes.io/name: prometheus-node-exporter
          app.kubernetes.io/instance: prometheus-node-exporter
      spec:
        automountServiceAccountToken: false
        securityContext:
          fsGroup: 65534
          runAsGroup: 65534
          runAsNonRoot: true
          runAsUser: 65534
        serviceAccountName: prometheus-node-exporter
        containers:
          - name: node-exporter
-           image: quay.io/prometheus/node-exporter:v1.5.0
+           image: quay.io/prometheus/node-exporter:v1.6.0
            imagePullPolicy: IfNotPresent
            args:
              - --path.procfs=/host/proc
              - --path.sysfs=/host/sys
              - --path.rootfs=/host/root
              - --path.udev.data=/host/root/run/udev/data
              - --web.listen-address=[$(HOST_IP)]:9100
            securityContext:
              readOnlyRootFilesystem: true
            env:
              - name: HOST_IP
                value: 0.0.0.0
            ports:
              - name: metrics
                containerPort: 9100
                protocol: TCP
            livenessProbe:
              failureThreshold: 3
              httpGet:
                httpHeaders:
                path: /
                port: 9100
                scheme: HTTP
              initialDelaySeconds: 0
              periodSeconds: 10
              successThreshold: 1
              timeoutSeconds: 1
            readinessProbe:
              failureThreshold: 3
              httpGet:
                httpHeaders:
                path: /
                port: 9100
                scheme: HTTP
              initialDelaySeconds: 0
              periodSeconds: 10
              successThreshold: 1
              timeoutSeconds: 1
            volumeMounts:
              - name: proc
                mountPath: /host/proc
                readOnly:  true
              - name: sys
                mountPath: /host/sys
                readOnly: true
              - name: root
                mountPath: /host/root
                mountPropagation: HostToContainer
                readOnly: true
        hostNetwork: true
        hostPID: true
+       nodeSelector:
+         kubernetes.io/os: linux
        tolerations:
          - effect: NoSchedule
            operator: Exists
        volumes:
          - name: proc
            hostPath:
              path: /proc
          - name: sys
            hostPath:
              path: /sys
          - name: root
            hostPath:
              path: /
default, prometheus-node-exporter, Service (v1) has changed:
  # Source: prometheus-node-exporter/templates/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: prometheus-node-exporter
    namespace: default
    labels:
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: metrics
      app.kubernetes.io/part-of: prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
    annotations:
+     prometheus.io/scrape: "true"
      prometheus.io/scrape: "true"
  spec:
    type: ClusterIP
    ports:
      - port: 9100
        targetPort: 9100
        protocol: TCP
        name: metrics
    selector:
      app.kubernetes.io/name: prometheus-node-exporter
      app.kubernetes.io/instance: prometheus-node-exporter
default, prometheus-node-exporter, ServiceAccount (v1) has changed:
```

</details>