### PR TITLE
chore: Update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,7 @@
 name: CI
 
 env:
-  VERSION_GO: '1.20.12'
-  VERSION_HELM: 'v3.13.3'
+  VERSION_HELM: 'v3.11.3'
 
 on:
   pull_request:
@@ -17,17 +16,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.VERSION_GO }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         run: make bootstrap
@@ -73,20 +65,20 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@v1.1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.VERSION_HELM }}
 
       - name: Setup WSL
         if: "contains(matrix.shell, 'wsl')"
-        uses: Vampire/setup-wsl@v1
+        uses: Vampire/setup-wsl@v2
 
       - name: Setup Cygwin
         if: "contains(matrix.shell, 'cygwin')"
-        uses: egor-tensin/setup-cygwin@v3
+        uses: egor-tensin/setup-cygwin@v4
         with:
           platform: x64
 
@@ -103,10 +95,10 @@ jobs:
         with:
           version: "v0.11.1"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Helm
-        uses: azure/setup-helm@v1.1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.VERSION_HELM }}
 
@@ -124,15 +116,3 @@ jobs:
 
       - name: helm diff upgrade -C 3 --set replicaCount=2 --install helm-diff ./helm-diff
         run: helm diff upgrade -C 3 --set replicaCount=2 --install helm-diff ./helm-diff
-
-  shell-lint:
-    name: Lint install-binary.sh
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: luizm/action-sh-checker@v0.3.0
-        with:
-          sh_checker_exclude: "scripts"
-          sh_checker_checkbashisms_enable: true

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,33 @@
+---
+name: Cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Cleanup PR cache'
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO="${{ github.repository }}"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/lint-sh.yaml
+++ b/.github/workflows/lint-sh.yaml
@@ -1,0 +1,22 @@
+name: Lint sh
+
+on:
+  push:
+    branches: [master]
+    paths: ['install-binary.sh']
+  pull_request:
+    branches: [master]
+    paths: ['install-binary.sh']
+
+jobs:
+  lint-sh:
+    name: Lint install-binary.sh
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: luizm/action-sh-checker@v0.7.0
+        with:
+          sh_checker_exclude: 'scripts'
+          sh_checker_checkbashisms_enable: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,23 +9,16 @@ on:
     branches: [ master ]
     paths-ignore: [ '**.md' ]
 
-env:
-  GO_VERSION: 1.19
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
-
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Golangci lint
-        uses: golangci/golangci-lint-action@v3
+          go-version-file: 'go.mod'
+      - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.0


### PR DESCRIPTION
- Added dependabot config for actions and go modules
- Update all actions to latest versions
- Move `shell-lint` job to separate workflow file with path filtered triggers
- Setup go version from `go.mod` file (caching is enabled by default)
- Add workflow to delete PR cache