### PR TITLE
docs(README): fix typo `upgarde` -> `upgrade`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ Examples:
   # Set HELM_DIFF_USE_UPGRADE_DRY_RUN=true to
   # use `helm upgrade --dry-run` instead of `helm template` to render manifests from the chart.
   # See https://github.com/databus23/helm-diff/issues/253 for more information.
-  HELM_DIFF_USE_UPGRADE_DRY_RUN=true helm diff upgarde my-release datadog/datadog
+  HELM_DIFF_USE_UPGRADE_DRY_RUN=true helm diff upgrade my-release datadog/datadog
 
   # Set HELM_DIFF_THREE_WAY_MERGE=true to
   # enable the three-way-merge on diff.
   # This is equivalent to specifying the --three-way-merge flag.
   # Read the flag usage below for more information on --three-way-merge.
-  HELM_DIFF_THREE_WAY_MERGE=true helm diff upgarde my-release datadog/datadog
+  HELM_DIFF_THREE_WAY_MERGE=true helm diff upgrade my-release datadog/datadog
 
   # Set HELM_DIFF_NORMALIZE_MANIFESTS=true to
   # normalize the yaml file content when using helm diff.


### PR DESCRIPTION
Hiya :wave:, finishing off what #421 started :D