### PR TITLE
Fix description of diff suppress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Flags:
       --set-string stringArray           set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --show-secrets                     do not redact secret values in the output
       --strip-trailing-cr                strip trailing carriage return on input
-      --suppress stringArray             allows suppression of the values listed in the diff output
+      --suppress stringArray             allows suppression of the kinds listed in the diff output (can specify multiple, like '--suppress Deployment --suppress Service')
   -q, --suppress-secrets                 suppress secrets in the output
       --three-way-merge                  use three-way-merge to compute patch and generate diff output
   -f, --values valueFiles                specify values in a YAML file (can specify multiple) (default [])

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,7 +10,7 @@ import (
 func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.BoolVar(&o.ShowSecrets, "show-secrets", false, "do not redact secret values in the output")
-	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the values listed in the diff output")
+	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the kinds listed in the diff output (can specify multiple, like '--suppress Deployment --suppress Service')")
 	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template, dyff. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
 	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")


### PR DESCRIPTION
As also mentioned in the issue below, the current `--suppress` option only handles kind, but the vague description is causing confusion.
ref: https://github.com/databus23/helm-diff/issues/163

I think #468 is the fundamental solution, but first I would like to clarify the current specifications.