### PR TITLE
Automate releases using GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.12'
+          go-version-file: 'go.mod'
           cache: true
       -
         name: Run GoReleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.12'
+          cache: true
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean ${{ env.flags }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,35 @@
+project_name: helm-diff
+builds:
+  - id: default
+    main: .
+    binary: bin/diff
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -X github.com/databus23/helm-diff/v3/cmd.Version={{ .Version }}
+    goos:
+      - freebsd
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: default
+    builds:
+    - default
+    format: tgz
+    name_template: '{{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ .Arch }}'
+    files:
+    - README.md
+    - plugin.yaml
+    - LICENSE
+changelog:
+  use: github-native
+
+release:
+  prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,7 @@
+# To test this manually, run:
+#  go install github.com/goreleaser/goreleaser@latest
+#  goreleaser --snapshot --clean
+#  for f in dist/helm-diff*.tgz; do echo Testing $f...; tar tzvf $f; done
 project_name: helm-diff
 builds:
   - id: default
@@ -24,6 +28,7 @@ archives:
     - default
     format: tgz
     name_template: '{{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ .Arch }}'
+    wrap_in_directory: diff
     files:
     - README.md
     - plugin.yaml


### PR DESCRIPTION
To publish a release, we currently have to run `make docker-run-release` locally after tagging a release, which is not a huge effort but a bit cumbersome because we do it only a few times a year and that is long enough to lose my memory :)

Starting this change, we use a GHA workflow and goreleaser to automatically build and publish binaries whenever a new semver tag is created, so that we do not need to run `make` anymore.

I crafted the goreleaser configuration so that it produces the same archives that we use and helm-diff's install.sh relies on.

For example, the produced archives has contents like the below:

- plugin.yaml
- README.md
- LICENSE
- bin/diff

`bin/diff` is especially important because that's the path we use in the plugin.yaml.

You can test this almost locally, by running `goreleaser --snapshot --clean`. Whenever you modify `.goreleaser.yml`, I'd recommend you running that for verification.

I bootstraped this from my other projects. But the end result turned out to be almost the same as @bonddim's awesome PR #480 submitted last July(!) so big applause to @bonddim for his awesome work!