### PR TITLE
Bump plugin version to 3.9.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.8.1"
+version: "3.9.0"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Once we merge this and cut a new v3.9.0 tag on GH web UI, #517 will automatically build and release binaries.