### PR TITLE
fix: remove debug msg in normal mode

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -173,8 +173,6 @@ func newChartCommand() *cobra.Command {
 					cmd.Flags().StringVar(&diff.dryRunMode, "dry-run", "", dryRunUsage)
 				}
 
-				fmt.Fprintf(os.Stderr, "args after legacy dry-run parsing: %v\n", args)
-
 				// Here we parse the flags ourselves so that we can support
 				// both --dry-run and --dry-run=ARG syntaxes.
 				//


### PR DESCRIPTION
```
+args after legacy dry-run parsing: [--allow-unreleased manifests /tmp/chartify3644874502/helmfile-tests/manifests --reset-values]
 ********************
 
 	Release was not present in Helm.  Diff will show entire contents as new.
FAIL: "helmfile diff" should be consistent
```

/cc @mumoshu 