### PR TITLE
Bump plugin version to 3.9.2

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.9.0"
+version: "3.9.2"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Missed bumping it when we released 3.9.1 🤦
We've already cut 3.9.1 so this prepares the next release, which might contain dep updates only.