### PR TITLE
Add support for resource-policy: keep (#246)

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -58,7 +58,9 @@ func Manifests(oldIndex, newIndex map[string]*manifest.MappingResult, options *O
 
 	for _, key := range removed {
 		oldContent := oldIndex[key]
-		doDiff(&report, key, oldContent, nil, options)
+		if oldContent.ResourcePolicy != "keep" {
+			doDiff(&report, key, oldContent, nil, options)
+		}
 	}
 
 	for _, key := range added {

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -11,16 +11,18 @@ import (
 )
 
 const (
-	hookAnnotation = "helm.sh/hook"
+	hookAnnotation           = "helm.sh/hook"
+	resourcePolicyAnnotation = "helm.sh/resource-policy"
 )
 
 var yamlSeparator = []byte("\n---\n")
 
 // MappingResult to store result of diff
 type MappingResult struct {
-	Name    string
-	Kind    string
-	Content string
+	Name           string
+	Kind           string
+	Content        string
+	ResourcePolicy string
 }
 
 type metadata struct {
@@ -169,9 +171,10 @@ func parseContent(content string, defaultNamespace string, normalizeManifests bo
 	name := parsedMetadata.String()
 	return []*MappingResult{
 		{
-			Name:    name,
-			Kind:    parsedMetadata.Kind,
-			Content: content,
+			Name:           name,
+			Kind:           parsedMetadata.Kind,
+			Content:        content,
+			ResourcePolicy: parsedMetadata.Metadata.Annotations[resourcePolicyAnnotation],
 		},
 	}, nil
 }


### PR DESCRIPTION
The annotation `helm.sh/resource-policy: keep` instructs Helm to skip deleting this resource when a Helm operation would result in its deletion. As the resource is not actually deleted, exclude it from the generated diff.