### PR TITLE
Implement support for pass-through of --set-literal flag/values

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -131,7 +131,7 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	// Helm automatically enable --reuse-values when there's no --set, --set-string, --set-json, --set-values, --set-file present.
 	// Let's simulate that in helm-diff.
 	// See https://medium.com/@kcatstack/understand-helm-upgrade-flags-reset-values-reuse-values-6e58ac8f127e
-	shouldDefaultReusingValues := isUpgrade && len(d.values) == 0 && len(d.stringValues) == 0 && len(d.jsonValues) == 0 && len(d.valueFiles) == 0 && len(d.fileValues) == 0
+	shouldDefaultReusingValues := isUpgrade && len(d.values) == 0 && len(d.stringValues) == 0 && len(d.stringLiteralValues) == 0 && len(d.jsonValues) == 0 && len(d.valueFiles) == 0 && len(d.fileValues) == 0
 	if (d.reuseValues || shouldDefaultReusingValues) && !d.resetValues && d.clusterAccessAllowed() {
 		tmpfile, err := os.CreateTemp("", "existing-values")
 		if err != nil {
@@ -150,6 +150,9 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	}
 	for _, stringValue := range d.stringValues {
 		flags = append(flags, "--set-string", stringValue)
+	}
+	for _, stringLiteralValue := range d.stringLiteralValues {
+		flags = append(flags, "--set-literal", stringLiteralValue)
 	}
 	for _, jsonValue := range d.jsonValues {
 		flags = append(flags, "--set-json", jsonValue)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -51,6 +51,7 @@ type diffCmd struct {
 	valueFiles               valueFiles
 	values                   []string
 	stringValues             []string
+	stringLiteralValues      []string
 	jsonValues               []string
 	fileValues               []string
 	reuseValues              bool
@@ -236,6 +237,7 @@ func newChartCommand() *cobra.Command {
 	f.VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
 	f.StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.StringArrayVar(&diff.stringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.StringArrayVar(&diff.stringLiteralValues, "set-literal", []string{}, "set STRING literal values on the command line")
 	f.StringArrayVar(&diff.jsonValues, "set-json", []string{}, "set JSON values on the command line (can specify multiple or separate values with commas: key1=jsonval1,key2=jsonval2)")
 	f.StringArrayVar(&diff.fileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
 	f.BoolVar(&diff.reuseValues, "reuse-values", false, "reuse the last release's values and merge in any new values. If '--reset-values' is specified, this is ignored")


### PR DESCRIPTION
Hi all,

this PR enables support for `--set-literal`, see https://github.com/helm/helm/pull/9182 and issue #474 here.