### PR TITLE
chore(deps): update Go toolchain version to 1.22.4 for CVE-2024-24790

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databus23/helm-diff/v3
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Updated the Go toolchain version from 1.22.2 to 1.22.4 in go.mod to ensure compatibility with the latest security patches.