### PR TITLE
feat(ci): update helm and go version in ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [ default ]
         experimental: [ false ]
-        helm-version: [ v3.15.4, v3.16.1 ]
+        helm-version: [ v3.15.4, v3.16.2 ]
         include:
           - os: windows-latest
             shell: wsl
@@ -61,16 +61,16 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.16.1
+            helm-version: v3.16.2
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.16.1
+            helm-version: v3.16.2
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.16.1
+            helm-version: v3.16.2
 
     steps:
       - name: Disable autocrlf
@@ -111,7 +111,7 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.15.4
-          - helm-version: v3.16.1
+          - helm-version: v3.16.2
     steps:
       - uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,4 +21,4 @@ jobs:
           go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.0
+          version: v1.61.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,8 +51,9 @@ run:
 
 # output configuration options
 output:
+  formats:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: line-number
+  - format: line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -291,7 +291,7 @@ linters:
     - depguard
     - errcheck
     - errorlint
-    - exportloopref
+    - copyloopvar
     - funlen
     - gci
     - gocognit

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -332,7 +332,7 @@ func printDiffRecords(suppressedKinds []string, kind string, context int, diffs 
 	for _, ckind := range suppressedKinds {
 		if ckind == kind {
 			str := fmt.Sprintf("+ Changes suppressed on sensitive content of type %s\n", kind)
-			fmt.Fprint(to, ansi.Color(str, "yellow"))
+			_, _ = fmt.Fprint(to, ansi.Color(str, "yellow"))
 			return
 		}
 	}
@@ -343,7 +343,7 @@ func printDiffRecords(suppressedKinds []string, kind string, context int, diffs 
 		for i, diff := range diffs {
 			if distances[i] > context {
 				if !omitting {
-					fmt.Fprintln(to, "...")
+					_, _ = fmt.Fprintln(to, "...")
 					omitting = true
 				}
 			} else {
@@ -368,7 +368,7 @@ func printDiffRecord(diff difflib.DiffRecord, to io.Writer) {
 		_, _ = fmt.Fprintf(to, "%s\n", ansi.Color("- "+text, "red"))
 	case difflib.Common:
 		if text == "" {
-			fmt.Fprintln(to)
+			_, _ = fmt.Fprintln(to)
 		} else {
 			_, _ = fmt.Fprintf(to, "%s\n", "  "+text)
 		}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -363,14 +363,14 @@ func printDiffRecord(diff difflib.DiffRecord, to io.Writer) {
 
 	switch diff.Delta {
 	case difflib.RightOnly:
-		fmt.Fprintf(to, "%s\n", ansi.Color("+ "+text, "green"))
+		_, _ = fmt.Fprintf(to, "%s\n", ansi.Color("+ "+text, "green"))
 	case difflib.LeftOnly:
-		fmt.Fprintf(to, "%s\n", ansi.Color("- "+text, "red"))
+		_, _ = fmt.Fprintf(to, "%s\n", ansi.Color("- "+text, "red"))
 	case difflib.Common:
 		if text == "" {
 			fmt.Fprintln(to)
 		} else {
-			fmt.Fprintf(to, "%s\n", "  "+text)
+			_, _ = fmt.Fprintf(to, "%s\n", "  "+text)
 		}
 	}
 }

--- a/diff/report.go
+++ b/diff/report.go
@@ -148,7 +148,7 @@ func setupDiffReport(r *Report) {
 // print report for default output: diff
 func printDiffReport(r *Report, to io.Writer) {
 	for _, entry := range r.entries {
-		fmt.Fprintf(to, ansi.Color("%s %s", "yellow")+"\n", entry.key, r.format.changestyles[entry.changeType].message)
+		_, _ = fmt.Fprintf(to, ansi.Color("%s %s", "yellow")+"\n", entry.key, r.format.changestyles[entry.changeType].message)
 		printDiffRecords(entry.suppressedKinds, entry.kind, entry.context, entry.diffs, to)
 	}
 }
@@ -170,13 +170,13 @@ func printSimpleReport(r *Report, to io.Writer) {
 		"MODIFY": 0,
 	}
 	for _, entry := range r.entries {
-		fmt.Fprintf(to, ansi.Color("%s %s", r.format.changestyles[entry.changeType].color)+"\n",
+		_, _ = fmt.Fprintf(to, ansi.Color("%s %s", r.format.changestyles[entry.changeType].color)+"\n",
 			entry.key,
 			r.format.changestyles[entry.changeType].message,
 		)
 		summary[entry.changeType]++
 	}
-	fmt.Fprintf(to, "Plan: %d to add, %d to change, %d to destroy.\n", summary["ADD"], summary["MODIFY"], summary["REMOVE"])
+	_, _ = fmt.Fprintf(to, "Plan: %d to add, %d to change, %d to destroy.\n", summary["ADD"], summary["MODIFY"], summary["REMOVE"])
 }
 
 func newTemplate(name string) *template.Template {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.23.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0

--- a/main_test.go
+++ b/main_test.go
@@ -76,7 +76,7 @@ func runFakeHelm() int {
 	var stub *fakeHelmSubcmd
 
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "fake helm does not support invocations without subcommands")
+		_, _ = fmt.Fprintln(os.Stderr, "fake helm does not support invocations without subcommands")
 		return 1
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -90,7 +90,7 @@ func runFakeHelm() int {
 	}
 
 	if stub == nil {
-		fmt.Fprintf(os.Stderr, "no stub for %s\n", cmdAndArgs)
+		_, _ = fmt.Fprintf(os.Stderr, "no stub for %s\n", cmdAndArgs)
 		return 1
 	}
 
@@ -100,13 +100,13 @@ func runFakeHelm() int {
 	}
 	got := cmdAndArgs[len(stub.cmd):]
 	if !reflect.DeepEqual(want, got) {
-		fmt.Fprintf(os.Stderr, "want: %v\n", want)
-		fmt.Fprintf(os.Stderr, "got : %v\n", got)
-		fmt.Fprintf(os.Stderr, "args : %v\n", os.Args)
-		fmt.Fprintf(os.Stderr, "env : %v\n", os.Environ())
+		_, _ = fmt.Fprintf(os.Stderr, "want: %v\n", want)
+		_, _ = fmt.Fprintf(os.Stderr, "got : %v\n", got)
+		_, _ = fmt.Fprintf(os.Stderr, "args : %v\n", os.Args)
+		_, _ = fmt.Fprintf(os.Stderr, "env : %v\n", os.Environ())
 		return 1
 	}
-	fmt.Fprintf(os.Stdout, "%s", stub.stdout)
-	fmt.Fprintf(os.Stderr, "%s", stub.stderr)
+	_, _ = fmt.Fprintf(os.Stdout, "%s", stub.stdout)
+	_, _ = fmt.Fprintf(os.Stderr, "%s", stub.stderr)
 	return stub.exitCode
 }


### PR DESCRIPTION
This pull request includes several updates to the CI and lint workflows, as well as a version upgrade in the `go.mod` file. The most important changes are the updates to the Helm and GolangCI versions, and the Go version in `go.mod`.

### CI Workflow Updates:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL46-R46): Updated Helm version from `v3.16.1` to `v3.16.2` across multiple job configurations. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL46-R46) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL64-R73) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL114-R114)

### Lint Workflow Updates:
* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL24-R24): Updated GolangCI-Lint version from `v1.56.0` to `v1.61.0`.

### Go Module Update:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated Go version from `1.22.0` to `1.23.2`.