### PR TITLE
feat: add skip-schema-validation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Flags:
       --disable-validation               disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install
       --dry-run                          disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation
       --enable-dns                       enable DNS lookups when rendering templates 
+      --skip-schema-validation           disables rendered templates validation against the Kubernetes OpenAPI Schema
   -D, --find-renames float32             Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                             help for diff
       --include-tests                    enable the diffing of the helm test hooks
@@ -184,6 +185,7 @@ Flags:
       --disable-validation               disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install
       --dry-run                          disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation
       --enable-dns                       enable DNS lookups when rendering templates 
+      --skip-schema-validation           skip validation of rendered templates against the Kubernetes OpenAPI Schema
   -D, --find-renames float32             Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                             help for upgrade
       --include-tests                    enable the diffing of the helm test hooks

--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -198,6 +198,10 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 		flags = append(flags, "--enable-dns")
 	}
 
+	if d.SkipSchemaValidation {
+		flags = append(flags, "--skip-schema-validation")
+	}
+
 	var (
 		subcmd string
 		filter func([]byte) []byte

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -47,6 +47,7 @@ type diffCmd struct {
 	disableValidation        bool
 	disableOpenAPIValidation bool
 	enableDNS                bool
+	SkipSchemaValidation     bool
 	namespace                string // namespace to assume the release to be installed into. Defaults to the current kube config namespace.
 	valueFiles               valueFiles
 	values                   []string
@@ -253,6 +254,7 @@ func newChartCommand() *cobra.Command {
 		" --dry-run=server enables the cluster access with helm-get and the lookup template function.")
 	f.Lookup("dry-run").NoOptDefVal = dryRunNoOptDefVal
 	f.BoolVar(&diff.enableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	f.BoolVar(&diff.SkipSchemaValidation, "skip-schema-validation", false, "skip validation of the rendered manifests against the Kubernetes OpenAPI schema")
 	f.StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
 	f.StringArrayVar(&diff.postRendererArgs, "post-renderer-args", []string{}, "an argument to the post-renderer (can specify multiple)")
 	f.BoolVar(&diff.insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")


### PR DESCRIPTION
https://github.com/helm/helm/pull/12743 Helm 3.16.0!



This pull request introduces a new option to skip schema validation when rendering templates in Helm 3. The key changes include adding a new flag and updating the relevant command structures and functions to support this new option.

New feature addition:

* [`cmd/helm3.go`](diffhunk://#diff-a0408f7d6a173149c3bcc5a85ae0fd7908f9baf448a1678fa755688373682fceR201-R204): Added support for the `--skip-schema-validation` flag in the `template` function to allow users to skip validation of rendered manifests against the Kubernetes OpenAPI schema.

Command structure updates:

* [`cmd/upgrade.go`](diffhunk://#diff-6b91a7cb88f6ad245b3fa4bc01b4789e1a23b940920626a6cffbffc0317ba2cfR50): Added a new field `SkipSchemaValidation` to the `diffCmd` struct to store the state of the new flag.
* [`cmd/upgrade.go`](diffhunk://#diff-6b91a7cb88f6ad245b3fa4bc01b4789e1a23b940920626a6cffbffc0317ba2cfR257): Updated the `newChartCommand` function to include the `--skip-schema-validation` flag, allowing users to specify it when running the command.