### PR TITLE
refactor(ci): remove redundant kind version in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,8 +114,6 @@ jobs:
           - helm-version: v3.16.2
     steps:
       - uses: engineerd/setup-kind@v0.6.2
-        with:
-          version: "v0.11.1"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,9 @@ jobs:
           - helm-version: v3.16.2
     steps:
       - uses: engineerd/setup-kind@v0.6.2
+        with:
+          skipClusterLogsExport: true 
+
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yaml` file. The change removes the `version` specification for the `engineerd/setup-kind` action, which previously was set to `v0.11.1`.