### PR TITLE
Bump helm-diff version to 3.9.13

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.9.12"
+version: "3.9.13"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request includes a small change to the `plugin.yaml` file. The change updates the version of the Helm plugin from `3.9.12` to `3.9.13` to reflect the latest build.