### PR TITLE
feat: Added windows support 

### DIFF
--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -1,0 +1,75 @@
+param (
+  [switch] $Update = $false
+)
+
+function Get-Architecture {
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+
+  $arch = switch ($architecture) {
+    "X64"  { "amd64" }
+    "Arm64" { "arm64" }
+    Default { "" }
+  }
+
+  if ($arch -eq "") {
+    throw "Unsupported architecture: ${architecture}"
+  }
+
+  return $arch
+}
+
+function Get-Version {
+  param ([Parameter(Mandatory=$true)][bool] $Update)
+
+  if ($Update) {
+    return "latest"
+  }
+
+  return git describe --tags --exact-match 2>$null || "latest"
+}
+
+function New-TemporaryDirectory {
+  $tmp = [System.IO.Path]::GetTempPath()
+  $name = (New-Guid).ToString("N")
+  $dir = New-Item -ItemType Directory -Path (Join-Path $tmp $name)
+  return $dir.FullName
+}
+
+function Get-Url {
+  param ([Parameter(Mandatory=$true)][string] $Version, [Parameter(Mandatory=$true)][string] $Architecture)
+
+  if ($Version -eq "latest") {
+    return "https://github.com/databus23/helm-diff/releases/latest/download/helm-diff-windows-${Architecture}.tgz"
+  }
+  return "https://github.com/databus23/helm-diff/releases/download/${Version}/helm-diff-windows-${Architecture}.tgz"
+}
+
+function Download-Plugin {
+  param ([Parameter(Mandatory=$true)][string] $Url, [Parameter(Mandatory=$true)][string] $Output)
+
+  Invoke-WebRequest -OutFile $Output $Url
+}
+
+function Install-Plugin {
+  param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
+
+  tar -xzf (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
+
+  New-Item -ItemType Directory -Path $Destination -Force
+  Copy-Item -Path (Join-Path $ArchiveDirectory "diff" "bin" "diff.exe") -Destination $Destination -Force
+}
+
+$ErrorActionPreference = "Stop"
+
+$archiveName = "helm-diff.tgz"
+$arch = Get-Architecture
+$version = Get-Version -Update $Update
+$tmpDir = New-TemporaryDirectory
+
+trap {  Remove-Item -path $tmpDir -Recurse -Force }
+
+$url = Get-Url -Version $version -Architecture $arch
+$output = Join-Path $tmpDir $archiveName
+
+Download-Plugin -Url $url -Output $output
+Install-Plugin -ArchiveDirectory $tmpDir -ArchiveName $archiveName -Destination (Join-Path $env:HELM_PLUGIN_DIR "bin")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,11 +1,29 @@
-name: "diff"
+name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.9.11"
-usage: "Preview helm upgrade changes as a diff"
-description: "Preview helm upgrade changes as a diff"
+version: 3.9.11
+usage: Preview helm upgrade changes as a diff
+description: Preview helm upgrade changes as a diff
 useTunnel: true
-command: "$HELM_PLUGIN_DIR/bin/diff"
-hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh -u"
+PlatformCommand:
+  - command: ${HELM_PLUGIN_DIR}/bin/diff
+  - os: windows
+    command: ${HELM_PLUGIN_DIR}\bin\diff.exe
+platformHooks:
+  install:
+    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+    - os: windows
+      command: pwsh
+      args:
+        - -c
+        - ${HELM_PLUGIN_DIR}/install-binary.ps1
+  update:
+    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+      args:
+        - -u
+    - os: windows
+      command: pwsh
+      args:
+        - -c
+        - ${HELM_PLUGIN_DIR}/install-binary.ps1
+        - -Update

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,25 +5,25 @@ version: 3.9.11
 usage: Preview helm upgrade changes as a diff
 description: Preview helm upgrade changes as a diff
 useTunnel: true
-PlatformCommand:
-  - command: ${HELM_PLUGIN_DIR}/bin/diff
-  - os: windows
-    command: ${HELM_PLUGIN_DIR}\bin\diff.exe
+platformCommand:
+    - command: ${HELM_PLUGIN_DIR}/bin/diff
+    - os: windows
+      command: ${HELM_PLUGIN_DIR}\bin\diff.exe
 platformHooks:
-  install:
-    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-    - os: windows
-      command: pwsh
-      args:
-        - -c
-        - ${HELM_PLUGIN_DIR}/install-binary.ps1
-  update:
-    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-      args:
-        - -u
-    - os: windows
-      command: pwsh
-      args:
-        - -c
-        - ${HELM_PLUGIN_DIR}/install-binary.ps1
-        - -Update
+    install:
+        - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+        - os: windows
+          command: pwsh
+          args:
+              - -c
+              - ${HELM_PLUGIN_DIR}/install-binary.ps1
+    update:
+        - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+          args:
+              - -u
+        - os: windows
+          command: pwsh
+          args:
+              - -c
+              - ${HELM_PLUGIN_DIR}/install-binary.ps1
+              - -Update


### PR DESCRIPTION
This pull request introduces significant changes to the installation and configuration of the Helm diff plugin, particularly adding support for Windows. The most important changes include the addition of a PowerShell script for installing the plugin on Windows and modifications to the `plugin.yaml` file to support platform-specific commands and hooks.

### Windows support and installation script:
* [`install-binary.ps1`](diffhunk://#diff-f11d28815cae60865e943e15c0c50a007d7e67140b67b84d036bb10278bb2984R1-R75): Added a PowerShell script to handle the installation and update of the Helm diff plugin on Windows. This script includes functions for determining the system architecture, retrieving the plugin version, creating a temporary directory, generating the download URL, downloading the plugin, and installing it.

### Configuration updates:
* [`plugin.yaml`](diffhunk://#diff-d55bf51ed4d80c9c0eef853d64823da5d91fad2e860465f50b40c355fd307afaL1-R29): Updated to include platform-specific commands and hooks for both Unix-based systems and Windows. This change ensures that the appropriate installation and update scripts are executed based on the operating system.