### PR TITLE
refactor(plugin.yaml): enhance platform support and update commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [ default ]
         experimental: [ false ]
-        helm-version: [ v3.18.6, v3.17.4 ]
+        helm-version: [ v3.18.6, v3.19.0-rc.1 ]
         include:
           - os: windows-latest
             shell: wsl
@@ -61,16 +61,16 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.17.4
+            helm-version: v3.19.0-rc.1
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.17.4
+            helm-version: v3.19.0-rc.1
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.17.4
+            helm-version: v3.19.0-rc.1
 
     steps:
       - name: Disable autocrlf
@@ -111,7 +111,7 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.6
-          - helm-version: v3.17.4
+          - helm-version: v3.19.0-rc.1
     steps:
       - uses: engineerd/setup-kind@v0.6.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,8 +93,6 @@ jobs:
       - name: Setup Cygwin
         if: "contains(matrix.shell, 'cygwin')"
         uses: egor-tensin/setup-cygwin@v4
-        with:
-          platform: x64
 
       - name: helm plugin install
         run: helm plugin install .

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -54,8 +54,7 @@ function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
   Push-Location $ArchiveDirectory
-  tar -xvzf $ArchiveName -C . 
-  Get-ChildItem -Path $ArchiveDirectory -Recurse
+  tar -xzf $ArchiveName -C . 
   Pop-Location
 
   New-Item -ItemType Directory -Path $Destination -Force

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,7 +53,9 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
-  tar --force-local -xzf (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
+  Push-Location $ArchiveDirectory
+  tar -xzf $ArchiveName -C $ArchiveDirectory
+  Pop-Location
 
   New-Item -ItemType Directory -Path $Destination -Force
   Copy-Item -Path (Join-Path $ArchiveDirectory "diff" "bin" "diff.exe") -Destination $Destination -Force

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -55,6 +55,7 @@ function Install-Plugin {
 
   Push-Location $ArchiveDirectory
   tar -xzf $ArchiveName -C $ArchiveDirectory
+  Get-ChildItem -Path $ArchiveDirectory -Recurse
   Pop-Location
 
   New-Item -ItemType Directory -Path $Destination -Force

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,7 +53,7 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
-  tar -xzf --force-local (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
+  tar --force-local -xzf (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
 
   New-Item -ItemType Directory -Path $Destination -Force
   Copy-Item -Path (Join-Path $ArchiveDirectory "diff" "bin" "diff.exe") -Destination $Destination -Force

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -1,0 +1,75 @@
+param (
+  [switch] $Update = $false
+)
+
+function Get-Architecture {
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+
+  $arch = switch ($architecture) {
+    "X64"  { "amd64" }
+    "Arm64" { "arm64" }
+    Default { "" }
+  }
+
+  if ($arch -eq "") {
+    throw "Unsupported architecture: ${architecture}"
+  }
+
+  return $arch
+}
+
+function Get-Version {
+  param ([Parameter(Mandatory=$true)][bool] $Update)
+
+  if ($Update) {
+    return "latest"
+  }
+
+  return git describe --tags --exact-match 2>$null || "latest"
+}
+
+function New-TemporaryDirectory {
+  $tmp = [System.IO.Path]::GetTempPath()
+  $name = (New-Guid).ToString("N")
+  $dir = New-Item -ItemType Directory -Path (Join-Path $tmp $name)
+  return $dir.FullName
+}
+
+function Get-Url {
+  param ([Parameter(Mandatory=$true)][string] $Version, [Parameter(Mandatory=$true)][string] $Architecture)
+
+  if ($Version -eq "latest") {
+    return "https://github.com/databus23/helm-diff/releases/latest/download/helm-diff-windows-${Architecture}.tgz"
+  }
+  return "https://github.com/databus23/helm-diff/releases/download/${Version}/helm-diff-windows-${Architecture}.tgz"
+}
+
+function Download-Plugin {
+  param ([Parameter(Mandatory=$true)][string] $Url, [Parameter(Mandatory=$true)][string] $Output)
+
+  Invoke-WebRequest -OutFile $Output $Url
+}
+
+function Install-Plugin {
+  param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
+
+  tar -xzf (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
+
+  New-Item -ItemType Directory -Path $Destination -Force
+  Copy-Item -Path (Join-Path $ArchiveDirectory "diff" "bin" "diff.exe") -Destination $Destination -Force
+}
+
+$ErrorActionPreference = "Stop"
+
+$archiveName = "helm-diff.tgz"
+$arch = Get-Architecture
+$version = Get-Version -Update $Update
+$tmpDir = New-TemporaryDirectory
+
+trap {  Remove-Item -path $tmpDir -Recurse -Force }
+
+$url = Get-Url -Version $version -Architecture $arch
+$output = Join-Path $tmpDir $archiveName
+
+Download-Plugin -Url $url -Output $output
+Install-Plugin -ArchiveDirectory $tmpDir -ArchiveName $archiveName -Destination (Join-Path $env:HELM_PLUGIN_DIR "bin")

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,9 +53,9 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
-  echo "archive directory: $ArchiveDirectory"
-  echo "archive name: $ArchiveName"
-  echo "destination: $Destination
+  Write-Host "Archive directory: $ArchiveDirectory"
+  Write-Host "Archive name: $ArchiveName"
+  Write-Host "Destination: $Destination"
   Push-Location $ArchiveDirectory
   tar -xvzf $ArchiveName -C $ArchiveDirectory
   Get-ChildItem -Path $ArchiveDirectory -Recurse

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -54,7 +54,7 @@ function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
   Push-Location $ArchiveDirectory
-  tar -xzf $ArchiveName -C $ArchiveDirectory
+  tar -xvzf $ArchiveName -C $ArchiveDirectory
   Get-ChildItem -Path $ArchiveDirectory -Recurse
   Pop-Location
 

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,11 +53,8 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
-  Write-Host "Archive directory: $ArchiveDirectory"
-  Write-Host "Archive name: $ArchiveName"
-  Write-Host "Destination: $Destination"
   Push-Location $ArchiveDirectory
-  tar -xvzf $ArchiveName -C $ArchiveDirectory
+  tar -xvzf $ArchiveName -C . 
   Get-ChildItem -Path $ArchiveDirectory -Recurse
   Pop-Location
 

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -54,6 +54,7 @@ function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
   Push-Location $ArchiveDirectory
+  tar --help
   tar -xvzf $ArchiveName -C $ArchiveDirectory
   Get-ChildItem -Path $ArchiveDirectory -Recurse
   Pop-Location

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,8 +53,10 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
+  echo "archive directory: $ArchiveDirectory"
+  echo "archive name: $ArchiveName"
+  echo "destination: $Destination
   Push-Location $ArchiveDirectory
-  tar --help
   tar -xvzf $ArchiveName -C $ArchiveDirectory
   Get-ChildItem -Path $ArchiveDirectory -Recurse
   Pop-Location

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -53,7 +53,7 @@ function Download-Plugin {
 function Install-Plugin {
   param ([Parameter(Mandatory=$true)][string] $ArchiveDirectory, [Parameter(Mandatory=$true)][string] $ArchiveName, [Parameter(Mandatory=$true)][string] $Destination)
 
-  tar -xzf (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
+  tar -xzf --force-local (Join-Path $ArchiveDirectory $ArchiveName) -C $ArchiveDirectory
 
   New-Item -ItemType Directory -Path $Destination -Force
   Copy-Item -Path (Join-Path $ArchiveDirectory "diff" "bin" "diff.exe") -Destination $Destination -Force

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,32 +6,25 @@ usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true
 platformCommand:
-  - os: linux 
-    command: "${HELM_PLUGIN_DIR}/install-binary.sh"
-  - os: darwin
-    command: "${HELM_PLUGIN_DIR}/install-binary.sh"
+  - command: ${HELM_PLUGIN_DIR}/bin/diff
   - os: windows
-    command: pwsh
-    args:
-      - -c
-      - ${HELM_PLUGIN_DIR}/install-binary.ps1
+    command: ${HELM_PLUGIN_DIR}\bin\diff.exe
 
-# v3.18.0+ only
-# platformHooks:
-#   install:
-#     - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-#     - os: windows
-#       command: pwsh
-#       args:
-#           - -c
-#           - ${HELM_PLUGIN_DIR}/install-binary.ps1
-#   update:
-#     - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-#       args:
-#         - -u
-#     - os: windows
-#       command: pwsh
-#       args:
-#         - -c
-#         - ${HELM_PLUGIN_DIR}/install-binary.ps1
-#         - -Update
+platformHooks:
+  install:
+    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+    - os: windows
+      command: pwsh
+      args:
+          - -c
+          - ${HELM_PLUGIN_DIR}/install-binary.ps1
+  update:
+    - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+      args:
+        - -u
+    - os: windows
+      command: pwsh
+      args:
+        - -c
+        - ${HELM_PLUGIN_DIR}/install-binary.ps1
+        - -Update

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,21 +9,22 @@ platformCommand:
   - command: ${HELM_PLUGIN_DIR}/bin/diff
   - os: windows
     command: ${HELM_PLUGIN_DIR}\bin\diff.exe
-platformHooks:
-    install:
-      - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-      - os: windows
-        command: pwsh
-        args:
-            - -c
-            - ${HELM_PLUGIN_DIR}/install-binary.ps1
-    update:
-      - command: ${HELM_PLUGIN_DIR}/install-binary.sh
-        args:
-          - -u
-      - os: windows
-        command: pwsh
-        args:
-          - -c
-          - ${HELM_PLUGIN_DIR}/install-binary.ps1
-          - -Update
+# v3.18.0+ only
+# platformHooks:
+#   install:
+#     - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+#     - os: windows
+#       command: pwsh
+#       args:
+#           - -c
+#           - ${HELM_PLUGIN_DIR}/install-binary.ps1
+#   update:
+#     - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+#       args:
+#         - -u
+#     - os: windows
+#       command: pwsh
+#       args:
+#         - -c
+#         - ${HELM_PLUGIN_DIR}/install-binary.ps1
+#         - -Update

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,9 +6,16 @@ usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true
 platformCommand:
-  - command: ${HELM_PLUGIN_DIR}/bin/diff
+  - os: linux 
+    command: "${HELM_PLUGIN_DIR}/install-binary.sh"
+  - os: darwin
+    command: "${HELM_PLUGIN_DIR}/install-binary.sh"
   - os: windows
-    command: ${HELM_PLUGIN_DIR}\bin\diff.exe
+    command: pwsh
+    args:
+      - -c
+      - ${HELM_PLUGIN_DIR}/install-binary.ps1
+
 # v3.18.0+ only
 # platformHooks:
 #   install:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,11 +1,29 @@
-name: "diff"
+name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
 version: "3.12.5"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true
-command: "$HELM_PLUGIN_DIR/bin/diff"
-hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh -u"
+platformCommand:
+  - command: ${HELM_PLUGIN_DIR}/bin/diff
+  - os: windows
+    command: ${HELM_PLUGIN_DIR}\bin\diff.exe
+platformHooks:
+    install:
+      - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+      - os: windows
+        command: pwsh
+        args:
+            - -c
+            - ${HELM_PLUGIN_DIR}/install-binary.ps1
+    update:
+      - command: ${HELM_PLUGIN_DIR}/install-binary.sh
+        args:
+          - -u
+      - os: windows
+        command: pwsh
+        args:
+          - -c
+          - ${HELM_PLUGIN_DIR}/install-binary.ps1
+          - -Update


### PR DESCRIPTION
This pull request introduces significant updates to the installation process and configuration for the Helm Diff plugin, particularly adding support for Windows.

fix: https://github.com/databus23/helm-diff/issues/316
### Installation Script Enhancements:
* Added a new PowerShell script `install-binary.ps1` to handle the installation process on Windows. This script includes functions for determining system architecture, fetching the appropriate plugin version, creating a temporary directory, constructing the download URL, downloading the plugin, and installing it.

### Configuration File Updates:
* Updated `plugin.yaml` to support platform-specific commands and hooks. This includes specifying different commands and hooks for Windows and other operating systems, ensuring compatibility across platforms.