### PR TITLE
Bump helm-diff version to 3.9.14

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.9.13"
+version: "3.9.14"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request includes a minor version update for the `plugin.yaml` file. The version number has been incremented from "3.9.13" to "3.9.14".

Changes in `plugin.yaml`:

* Updated version from "3.9.13" to "3.9.14".