### PR TITLE
Bump helm-diff version to 3.10.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.9.14"
+version: "3.10.0"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request includes a version update for the `diff` plugin in the `plugin.yaml` file. The version has been updated from `3.9.14` to `3.10.0` to reflect the latest changes.

* [`plugin.yaml`](diffhunk://#diff-d55bf51ed4d80c9c0eef853d64823da5d91fad2e860465f50b40c355fd307afaL4-R4): Updated the version from `3.9.14` to `3.10.0`.