### PR TITLE
build: update golang version to 1.24 and lint to v1.64.5

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,4 +21,4 @@ jobs:
           go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.23.2
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
This pull request includes updates to the Go version and the golangci-lint version used in the project.

Version updates:

* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL24-R24): Updated the `golangci-lint` action version from `v1.61.0` to `v1.64.5`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.2` to `1.24`.