### PR TITLE
test: Optimize deleteStatusAndTidyMetadata test assertion

### DIFF
--- a/manifest/util_test.go
+++ b/manifest/util_test.go
@@ -91,7 +91,7 @@ func Test_deleteStatusAndTidyMetadata(t *testing.T) {
 				t.Errorf("deleteStatusAndTidyMetadata() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.EqualValuesf(t, tt.want, got, "deleteStatusAndTidyMetadata() = %v, want %v", got, tt.want)
+			require.Equalf(t, tt.want, got, "deleteStatusAndTidyMetadata() = %v, want %v", got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
This pull request includes a small change to the `manifest/util_test.go` file. The change modifies the test assertion method used in the `Test_deleteStatusAndTidyMetadata` function to improve consistency and readability.

* [`manifest/util_test.go`](diffhunk://#diff-e9df6be45179cffae75a84c75b097fc5fac0b58b43bbdae3300603d0b7631851L94-R94): Changed `require.EqualValuesf` to `require.Equalf` in the `Test_deleteStatusAndTidyMetadata` function.