### PR TITLE
Allow diff to include crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Flags:
       --skip-schema-validation           disables rendered templates validation against the Kubernetes OpenAPI Schema
   -D, --find-renames float32             Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                             help for diff
+      --include-crds                     include CRDs in the diffing
       --include-tests                    enable the diffing of the helm test hooks
       --install                          enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match "helm upgrade --install" command
       --kube-version string              Kubernetes version used for Capabilities.KubeVersion
@@ -189,6 +190,7 @@ Flags:
       --skip-schema-validation           skip validation of rendered templates against the Kubernetes OpenAPI Schema
   -D, --find-renames float32             Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                             help for upgrade
+      --include-crds                     include CRDs in the diffing
       --include-tests                    enable the diffing of the helm test hooks
       --install                          enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match "helm upgrade --install" command
       --kube-version string              Kubernetes version used for Capabilities.KubeVersion

--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -113,6 +113,9 @@ func (d *diffCmd) template(isUpgrade bool) ([]byte, error) {
 	if d.noHooks && !d.useUpgradeDryRun {
 		flags = append(flags, "--no-hooks")
 	}
+	if d.includeCRDs {
+		flags = append(flags, "--include-crds")
+	}
 	if d.chartVersion != "" {
 		flags = append(flags, "--version", d.chartVersion)
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -53,6 +53,7 @@ type diffCmd struct {
 	allowUnreleased          bool
 	noHooks                  bool
 	includeTests             bool
+	includeCRDs              bool
 	postRenderer             string
 	postRendererArgs         []string
 	insecureSkipTLSVerify    bool
@@ -241,6 +242,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.install, "install", false, "enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match \"helm upgrade --install\" command")
 	f.BoolVar(&diff.noHooks, "no-hooks", false, "disable diffing of hooks")
 	f.BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
+	f.BoolVar(&diff.includeCRDs, "include-crds", false, "include CRDs in the diffing")
 	f.BoolVar(&diff.devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.")
 	f.BoolVar(&diff.disableValidation, "disable-validation", false, "disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install")
 	f.BoolVar(&diff.disableOpenAPIValidation, "disable-openapi-validation", false, "disables rendered templates validation against the Kubernetes OpenAPI Schema")


### PR DESCRIPTION
## Goal
This PR allows usage of `helm template` flag `--include-crds` during a `helm diff upgrade`.

### Before
When using `helmfile` with `helm diff upgrade` command you have to use post-renderer to get the fully rendered manifest and allow rendering of all resources including CRDs that are deployed via a sub-chart i.e. kyverno.

### Use Case
In order to be able to move a way from post-renderer and use `kustomization` builtin support of `helmfile` without breaking the manifest that you can get via `helm get manifest -n namespace release` it is needed to allow rendering the included crds if the chart decided to render these via a dependency.

It also makes `three-way-merge` more usefull as you now also get the diff for included crd changes.

### After
Merging this PR into an upcoming release would allow anyone to be able to catch changes to included crd changes during a `helm diff upgrade`.

### Breaking Changes?
None to be expected, the default is set to `false` which reflects the current behavior. You have to pass `--include-crds` excplitictly to also render included crds when calling template before diff when using three-way-merge
We used helm diff upgrade command in conjunction with helmfile with kustomize postrenderer.

### Follow up
`helmfile` maintainers could add this flag to `helmfile diff` command in future versions. Using just the patched version would need you to add `- "--include-crds"` to `helmDefaults.diffArgs` array.

(at)Others who read this - please upvote if you find this PR useful.