### PR TITLE
feat:support --dependency-update before upgrade

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -74,6 +74,12 @@ func getRelease(release, namespace string) ([]byte, error) {
 	return outputWithRichError(cmd)
 }
 
+func updateDependencies(chart string) ([]byte, error) {
+	args := []string{"dependency", "update", chart}
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return outputWithRichError(cmd)
+}
+
 func getHooks(release, namespace string) ([]byte, error) {
 	args := []string{"get", "hooks", release}
 	if namespace != "" {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -51,6 +51,7 @@ type diffCmd struct {
 	resetValues              bool
 	resetThenReuseValues     bool
 	allowUnreleased          bool
+	dependencyUpdate         bool
 	noHooks                  bool
 	includeTests             bool
 	includeCRDs              bool
@@ -240,6 +241,7 @@ func newChartCommand() *cobra.Command {
 	f.BoolVar(&diff.resetThenReuseValues, "reset-then-reuse-values", false, "reset the values to the ones built into the chart, apply the last release's values and merge in any new values. If '--reset-values' or '--reuse-values' is specified, this is ignored")
 	f.BoolVar(&diff.allowUnreleased, "allow-unreleased", false, "enables diffing of releases that are not yet deployed via Helm")
 	f.BoolVar(&diff.install, "install", false, "enables diffing of releases that are not yet deployed via Helm (equivalent to --allow-unreleased, added to match \"helm upgrade --install\" command")
+	f.BoolVar(&diff.dependencyUpdate, "dependency-update", false, "update dependencies if they are missing before diffing")
 	f.BoolVar(&diff.noHooks, "no-hooks", false, "disable diffing of hooks")
 	f.BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
 	f.BoolVar(&diff.includeCRDs, "include-crds", false, "include CRDs in the diffing")
@@ -270,6 +272,16 @@ func (d *diffCmd) runHelm3() error {
 	var releaseManifest []byte
 
 	var err error
+
+	if d.dependencyUpdate {
+		var output []byte
+		output, err = updateDependencies(d.chart)
+		if err != nil {
+			return err
+		} else {
+			fmt.Println(string(output))
+		}
+	}
 
 	if d.takeOwnership {
 		// We need to do a three way merge between the manifests of the new


### PR DESCRIPTION

When using `helm diff upgrade` command when chart dependencies in `charts` are absent you have to add run `helm dep up chart`.

I want to be able to pass most of the arguments that I also use in `helm upgrade` command. This allows me to reduce duplication and ensure `helm diff upgrade` uses the same flags as `helm upgrade` be passing the same `${args}` variable.

Tested with helm version `3.17.1`.