### PR TITLE
add secret decode diff

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,6 +10,7 @@ import (
 func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.BoolP("suppress-secrets", "q", false, "suppress secrets in the output")
 	f.BoolVar(&o.ShowSecrets, "show-secrets", false, "do not redact secret values in the output")
+	f.BoolVar(&o.DecodeSecrets, "decode-secrets", false, "decode secret values in the output")
 	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the kinds listed in the diff output (can specify multiple, like '--suppress Deployment --suppress Service')")
 	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template, dyff. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -25,6 +25,7 @@ type Options struct {
 	OutputContext             int
 	StripTrailingCR           bool
 	ShowSecrets               bool
+	DecodeSecrets             bool
 	SuppressedKinds           []string
 	FindRenames               float32
 	SuppressedOutputLineRegex []string
@@ -179,8 +180,11 @@ func contentSearch(report *Report, possiblyRemoved []string, oldIndex map[string
 				continue
 			}
 
-			if !options.ShowSecrets {
+			switch {
+			case !options.ShowSecrets:
 				redactSecrets(oldContent, newContent)
+			case options.DecodeSecrets && options.ShowSecrets:
+				decodeSecrets(oldContent, newContent)
 			}
 
 			diff := diffMappingResults(oldContent, newContent, options.StripTrailingCR)
@@ -212,9 +216,11 @@ func doDiff(report *Report, key string, oldContent *manifest.MappingResult, newC
 	if oldContent != nil && newContent != nil && oldContent.Content == newContent.Content {
 		return
 	}
-
-	if !options.ShowSecrets {
+	switch {
+	case !options.ShowSecrets:
 		redactSecrets(oldContent, newContent)
+	case options.DecodeSecrets && options.ShowSecrets:
+		decodeSecrets(oldContent, newContent)
 	}
 
 	if oldContent == nil {
@@ -233,7 +239,9 @@ func doDiff(report *Report, key string, oldContent *manifest.MappingResult, newC
 	}
 }
 
+// redactSecrets redacts secrets from the diff output.
 func redactSecrets(old, new *manifest.MappingResult) {
+	var oldSecretDecodeErr, newSecretDecodeErr error
 	if (old != nil && old.Kind != "Secret") || (new != nil && new.Kind != "Secret") {
 		return
 	}
@@ -242,33 +250,37 @@ func redactSecrets(old, new *manifest.MappingResult) {
 	var oldSecret, newSecret v1.Secret
 
 	if old != nil {
-		if err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(old.Content)).Decode(&oldSecret); err != nil {
-			old.Content = fmt.Sprintf("Error parsing old secret: %s", err)
-		}
-		//if we have a Secret containing `stringData`, apply the same
-		//transformation that the apiserver would do with it (this protects
-		//stringData keys from being overwritten down below)
-		if len(oldSecret.StringData) > 0 && oldSecret.Data == nil {
-			oldSecret.Data = make(map[string][]byte, len(oldSecret.StringData))
-		}
-		for k, v := range oldSecret.StringData {
-			oldSecret.Data[k] = []byte(v)
+		oldSecretDecodeErr = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(old.Content)).Decode(&oldSecret)
+		if oldSecretDecodeErr != nil {
+			old.Content = fmt.Sprintf("Error parsing old secret: %s", oldSecretDecodeErr)
+		} else {
+			//if we have a Secret containing `stringData`, apply the same
+			//transformation that the apiserver would do with it (this protects
+			//stringData keys from being overwritten down below)
+			if len(oldSecret.StringData) > 0 && oldSecret.Data == nil {
+				oldSecret.Data = make(map[string][]byte, len(oldSecret.StringData))
+			}
+			for k, v := range oldSecret.StringData {
+				oldSecret.Data[k] = []byte(v)
+			}
 		}
 	}
 	if new != nil {
-		if err := yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(new.Content)).Decode(&newSecret); err != nil {
-			new.Content = fmt.Sprintf("Error parsing new secret: %s", err)
-		}
-		//same as above
-		if len(newSecret.StringData) > 0 && newSecret.Data == nil {
-			newSecret.Data = make(map[string][]byte, len(newSecret.StringData))
-		}
-		for k, v := range newSecret.StringData {
-			newSecret.Data[k] = []byte(v)
+		newSecretDecodeErr = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(new.Content)).Decode(&newSecret)
+		if newSecretDecodeErr != nil {
+			new.Content = fmt.Sprintf("Error parsing new secret: %s", newSecretDecodeErr)
+		} else {
+			//same as above
+			if len(newSecret.StringData) > 0 && newSecret.Data == nil {
+				newSecret.Data = make(map[string][]byte, len(newSecret.StringData))
+			}
+			for k, v := range newSecret.StringData {
+				newSecret.Data[k] = []byte(v)
+			}
 		}
 	}
 
-	if old != nil {
+	if old != nil && oldSecretDecodeErr == nil {
 		oldSecret.StringData = make(map[string]string, len(oldSecret.Data))
 		for k, v := range oldSecret.Data {
 			if new != nil && bytes.Equal(v, newSecret.Data[k]) {
@@ -278,7 +290,7 @@ func redactSecrets(old, new *manifest.MappingResult) {
 			}
 		}
 	}
-	if new != nil {
+	if new != nil && newSecretDecodeErr == nil {
 		newSecret.StringData = make(map[string]string, len(newSecret.Data))
 		for k, v := range newSecret.Data {
 			if old != nil && bytes.Equal(v, oldSecret.Data[k]) {
@@ -290,21 +302,81 @@ func redactSecrets(old, new *manifest.MappingResult) {
 	}
 
 	// remove Data field now that we are using StringData for serialization
-	var buf bytes.Buffer
-	if old != nil {
+	if old != nil && oldSecretDecodeErr == nil {
+		oldSecretBuf := bytes.NewBuffer(nil)
 		oldSecret.Data = nil
-		if err := serializer.Encode(&oldSecret, &buf); err != nil {
+		if err := serializer.Encode(&oldSecret, oldSecretBuf); err != nil {
 			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
 		}
-		old.Content = getComment(old.Content) + strings.Replace(strings.Replace(buf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
-		buf.Reset() //reuse buffer for new secret
+		old.Content = getComment(old.Content) + strings.Replace(strings.Replace(oldSecretBuf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
+		oldSecretBuf.Reset()
+	}
+	if new != nil && newSecretDecodeErr == nil {
+		newSecretBuf := bytes.NewBuffer(nil)
+		newSecret.Data = nil
+		if err := serializer.Encode(&newSecret, newSecretBuf); err != nil {
+			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
+		}
+		new.Content = getComment(new.Content) + strings.Replace(strings.Replace(newSecretBuf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
+		newSecretBuf.Reset()
+	}
+}
+
+// decodeSecrets decodes secrets from the diff output.
+func decodeSecrets(old, new *manifest.MappingResult) {
+	var oldSecretDecodeErr, newSecretDecodeErr error
+	if (old != nil && old.Kind != "Secret") || (new != nil && new.Kind != "Secret") {
+		return
+	}
+	serializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
+		scheme.Scheme)
+	var oldSecret, newSecret v1.Secret
+
+	if old != nil {
+		oldSecretDecodeErr = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(old.Content)).Decode(&oldSecret)
+		if oldSecretDecodeErr != nil {
+			old.Content = fmt.Sprintf("Error parsing old secret: %s", oldSecretDecodeErr)
+		} else {
+			if len(oldSecret.Data) > 0 && oldSecret.StringData == nil {
+				oldSecret.StringData = make(map[string]string, len(oldSecret.Data))
+			}
+			for k, v := range oldSecret.Data {
+				oldSecret.StringData[k] = string(v)
+			}
+		}
 	}
 	if new != nil {
-		newSecret.Data = nil
-		if err := serializer.Encode(&newSecret, &buf); err != nil {
+		newSecretDecodeErr = yaml.NewYAMLToJSONDecoder(bytes.NewBufferString(new.Content)).Decode(&newSecret)
+		if newSecretDecodeErr != nil {
+			new.Content = fmt.Sprintf("Error parsing new secret: %s", newSecretDecodeErr)
+		} else {
+			if len(newSecret.Data) > 0 && newSecret.StringData == nil {
+				newSecret.StringData = make(map[string]string, len(newSecret.StringData))
+			}
+			for k, v := range newSecret.Data {
+				newSecret.StringData[k] = string(v)
+			}
+		}
+	}
+
+	// remove Data field now that we are using StringData for serialization
+	if old != nil && oldSecretDecodeErr == nil {
+		oldSecretBuf := bytes.NewBuffer(nil)
+		oldSecret.Data = nil
+		if err := serializer.Encode(&oldSecret, oldSecretBuf); err != nil {
 			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
 		}
-		new.Content = getComment(new.Content) + strings.Replace(strings.Replace(buf.String(), "stringData", "data", 1), "  creationTimestamp: null\n", "", 1)
+		old.Content = getComment(old.Content) + strings.Replace(oldSecretBuf.String(), "  creationTimestamp: null\n", "", 1)
+		oldSecretBuf.Reset()
+	}
+	if new != nil && newSecretDecodeErr == nil {
+		newSecretBuf := bytes.NewBuffer(nil)
+		newSecret.Data = nil
+		if err := serializer.Encode(&newSecret, newSecretBuf); err != nil {
+			new.Content = fmt.Sprintf("Error encoding new secret: %s", err)
+		}
+		new.Content = getComment(new.Content) + strings.Replace(newSecretBuf.String(), "  creationTimestamp: null\n", "", 1)
+		newSecretBuf.Reset()
 	}
 }
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -277,7 +277,7 @@ annotations:
 
 	t.Run("OnChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -296,7 +296,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{"apiVersion"}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}}
 
 		if changesSeen := Manifests(specBeta, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -315,7 +315,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppressAll", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{"apiVersion"}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -327,7 +327,7 @@ annotations:
 
 	t.Run("OnChangeRename", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamed, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -348,7 +348,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndUpdate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndUpdated, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -370,7 +370,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAdded", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -394,7 +394,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAddedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{"app: "}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -417,7 +417,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -441,7 +441,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemovedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{"app: "}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -464,7 +464,7 @@ annotations:
 
 	t.Run("OnNoChange", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -475,7 +475,7 @@ annotations:
 
 	t.Run("OnChangeRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
 
 		if changesSeen := Manifests(specRelease, nil, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -493,7 +493,7 @@ annotations:
 
 	t.Run("OnChangeRemovedWithResourcePolicyKeep", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specReleaseKeep, nil, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -504,7 +504,7 @@ annotations:
 
 	t.Run("OnChangeSimple", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -517,7 +517,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeSimple", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}}
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
@@ -527,7 +527,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -545,7 +545,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeJSON", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"json", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"json", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -563,7 +563,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -575,7 +575,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		os.Setenv("HELM_DIFF_TPL", "testdata/customTemplate.tpl")
-		diffOptions := Options{"template", 10, false, true, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -658,7 +658,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithByteData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithByteData, specSecretWithByteDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -683,7 +683,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithStringData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithStringData, specSecretWithStringDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -807,7 +807,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithoutSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		newOwnedReleases := map[string]OwnershipDiff{
 			"default, foobar, ConfigMap (v1)": {
@@ -827,7 +827,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}} //NOTE: ShowSecrets = false
 
 		specNew := map[string]*manifest.MappingResult{
 			"default, foobar, ConfigMap (v1)": {
@@ -867,5 +867,286 @@ default, foobar, ConfigMap (v1) has changed:
 +   key1: newValue1
 
 `, buf1.String())
+	})
+}
+func TestDecodeSecrets(t *testing.T) {
+	ansi.DisableColors(true)
+
+	t.Run("decodeSecrets with valid base64 data", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: dmFsdWUx
+  key2: dmFsdWUy
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: bmV3dmFsdWUx
+  key2: dmFsdWUy
+`,
+		}
+		decodeSecrets(old, new)
+		require.Contains(t, old.Content, "key1: value1")
+		require.Contains(t, old.Content, "key2: value2")
+		require.Contains(t, new.Content, "key1: newvalue1")
+		require.Contains(t, new.Content, "key2: value2")
+	})
+
+	t.Run("decodeSecrets with stringData", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1
+  key2: value2
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1changed
+  key2: value2
+`,
+		}
+		decodeSecrets(old, new)
+		require.Contains(t, old.Content, "key1: value1")
+		require.Contains(t, old.Content, "key2: value2")
+		require.Contains(t, new.Content, "key1: value1changed")
+		require.Contains(t, new.Content, "key2: value2")
+	})
+
+	t.Run("decodeSecrets with invalid base64", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: invalidbase64
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: dmFsdWUx
+`,
+		}
+		decodeSecrets(old, new)
+		require.Contains(t, old.Content, "Error parsing old secret")
+		require.Contains(t, new.Content, "key1: value1")
+	})
+
+	t.Run("decodeSecrets with non-Secret kind", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name:    "default, foo, ConfigMap (v1)",
+			Kind:    "ConfigMap",
+			Content: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: foo\n",
+		}
+		new := &manifest.MappingResult{
+			Name:    "default, foo, ConfigMap (v1)",
+			Kind:    "ConfigMap",
+			Content: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: foo\n",
+		}
+		origOld := old.Content
+		origNew := new.Content
+		decodeSecrets(old, new)
+		require.Equal(t, origOld, old.Content)
+		require.Equal(t, origNew, new.Content)
+	})
+
+	t.Run("decodeSecrets with nil arguments", func(t *testing.T) {
+		// Should not panic or change anything
+		decodeSecrets(nil, nil)
+	})
+}
+
+func TestRedactSecrets(t *testing.T) {
+	ansi.DisableColors(true)
+
+	t.Run("redactSecrets with valid base64 data", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: dmFsdWUx
+  key2: dmFsdWUy
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: bmV3dmFsdWUx
+  key2: dmFsdWUy
+`,
+		}
+		redactSecrets(old, new)
+		require.Contains(t, old.Content, "key1: '-------- # (6 bytes)'")
+		require.Contains(t, old.Content, "key2: 'REDACTED # (6 bytes)'")
+		require.Contains(t, new.Content, "key1: '++++++++ # (9 bytes)'")
+		require.Contains(t, new.Content, "key2: 'REDACTED # (6 bytes)'")
+	})
+
+	t.Run("redactSecrets with stringData", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1
+  key2: value2
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1changed
+  key2: value2
+`,
+		}
+		redactSecrets(old, new)
+		require.Contains(t, old.Content, "key1: '-------- # (6 bytes)'")
+		require.Contains(t, old.Content, "key2: 'REDACTED # (6 bytes)'")
+		require.Contains(t, new.Content, "key1: '++++++++ # (13 bytes)'")
+		require.Contains(t, new.Content, "key2: 'REDACTED # (6 bytes)'")
+	})
+
+	t.Run("redactSecrets with nil arguments", func(t *testing.T) {
+		// Should not panic or change anything
+		redactSecrets(nil, nil)
+	})
+
+	t.Run("redactSecrets with non-Secret kind", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name:    "default, foo, ConfigMap (v1)",
+			Kind:    "ConfigMap",
+			Content: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: foo\n",
+		}
+		new := &manifest.MappingResult{
+			Name:    "default, foo, ConfigMap (v1)",
+			Kind:    "ConfigMap",
+			Content: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: foo\n",
+		}
+		origOld := old.Content
+		origNew := new.Content
+		redactSecrets(old, new)
+		require.Equal(t, origOld, old.Content)
+		require.Equal(t, origNew, new.Content)
+	})
+
+	t.Run("redactSecrets with invalid YAML", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name:    "default, foo, Secret (v1)",
+			Kind:    "Secret",
+			Content: "invalid: yaml: :::",
+		}
+		new := &manifest.MappingResult{
+			Name:    "default, foo, Secret (v1)",
+			Kind:    "Secret",
+			Content: "invalid: yaml: :::",
+		}
+		redactSecrets(old, new)
+		require.Contains(t, old.Content, "Error parsing old secret")
+		require.Contains(t, new.Content, "Error parsing new secret")
+	})
+
+	t.Run("redactSecrets with only old secret", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: dmFsdWUx
+`,
+		}
+		redactSecrets(old, nil)
+		require.Contains(t, old.Content, "key1: '-------- # (6 bytes)'")
+	})
+
+	t.Run("redactSecrets with only new secret", func(t *testing.T) {
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+data:
+  key1: dmFsdWUx
+`,
+		}
+		redactSecrets(nil, new)
+		require.Contains(t, new.Content, "key1: '++++++++ # (6 bytes)'")
 	})
 }


### PR DESCRIPTION
This pull request introduces a new feature to handle secret values in diff outputs by adding the ability to decode secrets in addition to the existing options to redact or show them. It includes changes to the core logic, new helper functions, and updates to the test cases to support and validate this functionality.

### Feature Enhancements:
* Added a new `--decode-secrets` flag in `cmd/options.go` to enable decoding of secret values in the diff output. This flag is mapped to the new `DecodeSecrets` field in the `Options` struct. [[1]](diffhunk://#diff-0d760e4a0129cd8e3e654a60be4b482147cb719a97adc168ef9c2bce52799b56R13) [[2]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fR28)

* Introduced a new `decodeSecrets` function in `diff/diff.go` to handle the decoding of secret values. This function converts binary data in the `Data` field of Kubernetes secrets into human-readable strings in the `StringData` field.

### Core Logic Updates:
* Updated the `doDiff` and `contentSearch` functions in `diff/diff.go` to incorporate the new `DecodeSecrets` option. Depending on the combination of `ShowSecrets` and `DecodeSecrets` flags, secrets are either redacted, decoded, or displayed as-is. [[1]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL182-R187) [[2]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL215-R223)

* Enhanced the existing `redactSecrets` function to improve error handling and ensure that decoding errors are properly managed when redacting secrets. [[1]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fR242-R244) [[2]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL245-R256) [[3]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL258-R272)

### Test Suite Updates:
* Modified the test cases in `diff_test.go` to include the new `DecodeSecrets` flag. Updated all relevant test scenarios to ensure the new functionality is correctly validated. [[1]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L280-R280) [[2]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L299-R299) [[3]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L318-R318) [[4]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L330-R330) [[5]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L351-R351) [[6]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L373-R373) [[7]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L397-R397) [[8]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L420-R420) [[9]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L444-R444) [[10]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L467-R467) [[11]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L478-R478) [[12]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L496-R496) [[13]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L507-R507) [[14]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L520-R520) [[15]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L530-R530) [[16]](diffhunk://#diff-b7c47b27bdc20f1eab8954afa4cba55f2f13de4f4e57019f955772042c30db92L548-R548)