### PR TITLE
refactor(diff): extract secret handling to preHandleSecrets

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -943,6 +943,48 @@ stringData:
 		require.Contains(t, new.Content, "key1: value1changed")
 		require.Contains(t, new.Content, "key2: value2")
 	})
+	t.Run("decodeSecrets with stringData and Data that stringData precedes data on Secrets", func(t *testing.T) {
+		old := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1
+  key2: value2
+data:
+  key2: dmFsdWUyaW5kYXRh
+  key3: dmFsdWUz
+`,
+		}
+		new := &manifest.MappingResult{
+			Name: "default, foo, Secret (v1)",
+			Kind: "Secret",
+			Content: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo
+type: Opaque
+stringData:
+  key1: value1changed
+  key2: value2
+data:
+  key3: dmFsdWUzaW5kYXRh
+`,
+		}
+		decodeSecrets(old, new)
+		require.Contains(t, old.Content, "key1: value1")
+		require.Contains(t, old.Content, "key2: value2")
+		require.Contains(t, old.Content, "key3: value3")
+		require.Contains(t, new.Content, "key1: value1changed")
+		require.Contains(t, new.Content, "key2: value2")
+		require.Contains(t, new.Content, "key3: value3indata")
+	})
 
 	t.Run("decodeSecrets with invalid base64", func(t *testing.T) {
 		old := &manifest.MappingResult{

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -943,7 +943,7 @@ stringData:
 		require.Contains(t, new.Content, "key1: value1changed")
 		require.Contains(t, new.Content, "key2: value2")
 	})
-	t.Run("decodeSecrets with stringData and Data that stringData precedes data on Secrets", func(t *testing.T) {
+	t.Run("decodeSecrets with stringData and data ensuring that stringData always precedes/overrides data on Secrets", func(t *testing.T) {
 		old := &manifest.MappingResult{
 			Name: "default, foo, Secret (v1)",
 			Kind: "Secret",

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -954,11 +954,11 @@ metadata:
   name: foo
 type: Opaque
 stringData:
-  key1: value1
-  key2: value2
+  key1: value1.stringdata
+  key2: value2.stringdata
 data:
-  key2: dmFsdWUyaW5kYXRh
-  key3: dmFsdWUz
+  key2: dmFsdWUyLmRhdGE=
+  key3: dmFsdWUzLmRhdGE=
 `,
 		}
 		new := &manifest.MappingResult{
@@ -971,19 +971,19 @@ metadata:
   name: foo
 type: Opaque
 stringData:
-  key1: value1changed
-  key2: value2
+  key1: value1changed.stringdata
+  key2: value2.stringdata
 data:
-  key3: dmFsdWUzaW5kYXRh
+  key3: dmFsdWUzLmRhdGE=
 `,
 		}
 		decodeSecrets(old, new)
-		require.Contains(t, old.Content, "key1: value1")
-		require.Contains(t, old.Content, "key2: value2")
-		require.Contains(t, old.Content, "key3: value3")
-		require.Contains(t, new.Content, "key1: value1changed")
-		require.Contains(t, new.Content, "key2: value2")
-		require.Contains(t, new.Content, "key3: value3indata")
+		require.Contains(t, old.Content, "key1: value1.stringdata")
+		require.Contains(t, old.Content, "key2: value2.stringdata")
+		require.Contains(t, old.Content, "key3: value3.data")
+		require.Contains(t, new.Content, "key1: value1changed.stringdata")
+		require.Contains(t, new.Content, "key2: value2.stringdata")
+		require.Contains(t, new.Content, "key3: value3.data")
 	})
 
 	t.Run("decodeSecrets with invalid base64", func(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the handling of secrets in the `diff` package to improve code reuse and readability. The changes include introducing a helper function for decoding secrets, updating related methods to use this helper, and adding a new test case to ensure correct behavior when both `stringData` and `data` fields are present in Kubernetes secrets.

### Refactoring for code reuse and clarity:
* Introduced a new helper function `preHandleSecrets` in `diff/diff.go` to centralize the logic for decoding secrets and handling errors. This function is now used in both `redactSecrets` and `decodeSecrets` to avoid code duplication. [[1]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL242-L251) [[2]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fR275-R285) [[3]](diffhunk://#diff-9b5d2fa5162a9c23e7b0c96446b28d54aa4c6676a697d2eb26073a5a76db602fL327-L360)

### Testing improvements:
* Added a new test case in `diff_test.go` to verify that `decodeSecrets` correctly prioritizes `stringData` over `data` when both fields are present in Kubernetes secrets. This ensures the expected behavior when handling secret resources.