### PR TITLE
refactor(Makefile): use HELM_DATA_HOME instead of HELM_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HELM_HOME ?= $(shell helm home)
+HELM_DATA_HOME ?= $(shell helm env HELM_DATA_HOME)
 VERSION := $(shell sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' plugin.yaml)
 
 HELM_3_PLUGINS := $(shell helm env HELM_PLUGINS)
@@ -15,9 +15,9 @@ format:
 
 .PHONY: install
 install: build
-	mkdir -p $(HELM_HOME)/plugins/helm-diff/bin
-	cp bin/diff $(HELM_HOME)/plugins/helm-diff/bin
-	cp plugin.yaml $(HELM_HOME)/plugins/helm-diff/
+	mkdir -p $(HELM_DATA_HOME)/plugins/helm-diff/bin
+	cp bin/diff $(HELM_DATA_HOME)/plugins/helm-diff/bin
+	cp plugin.yaml $(HELM_DATA_HOME)/plugins/helm-diff/
 
 .PHONY: install/helm3
 install/helm3: build


### PR DESCRIPTION
This pull request updates the `Makefile` to align with Helm's newer environment variable conventions by replacing the deprecated `HELM_HOME` with `HELM_DATA_HOME`. The changes ensure compatibility with Helm 3 and improve maintainability.

### Updates to Helm environment variable usage:

* Replaced `HELM_HOME` with `HELM_DATA_HOME` in the `Makefile` to use the newer Helm environment variable for plugin data storage.
* Updated the `install` target to reflect the change from `HELM_HOME` to `HELM_DATA_HOME` for creating directories and copying files during plugin installation.