### PR TITLE
refactor(Makefile): Replace HELM_DATA_HOME with HELM_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HELM_DATA_HOME ?= $(shell helm env HELM_DATA_HOME)
+HELM_HOME ?= $(shell helm env HELM_DATA_HOME)
 VERSION := $(shell sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' plugin.yaml)
 
 HELM_3_PLUGINS := $(shell helm env HELM_PLUGINS)
@@ -15,9 +15,9 @@ format:
 
 .PHONY: install
 install: build
-	mkdir -p $(HELM_DATA_HOME)/plugins/helm-diff/bin
-	cp bin/diff $(HELM_DATA_HOME)/plugins/helm-diff/bin
-	cp plugin.yaml $(HELM_DATA_HOME)/plugins/helm-diff/
+	mkdir -p $(HELM_HOME)/plugins/helm-diff/bin
+	cp bin/diff $(HELM_HOME)/plugins/helm-diff/bin
+	cp plugin.yaml $(HELM_HOME)/plugins/helm-diff/
 
 .PHONY: install/helm3
 install/helm3: build


### PR DESCRIPTION
This pull request updates the `Makefile` to standardize the use of the `HELM_HOME` variable instead of `HELM_DATA_HOME` for consistency in Helm environment configuration.

### Standardization of Helm environment variable:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1): Replaced `HELM_DATA_HOME` with `HELM_HOME` throughout the file to align with Helm's environment variable naming conventions. This includes updates in the variable definition and the `install` target commands. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L18-R20)