### PR TITLE
Bump helm-diff version to 3.12.1

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.12.0"
+version: "3.12.1"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request includes a minor version update to the `plugin.yaml` file. The change updates the plugin's version from `3.12.0` to `3.12.1`, reflecting a new build.