### PR TITLE
fix: remove redundant Helm release not found message

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -276,7 +276,6 @@ func (d *diffCmd) runHelm3() error {
 	var newInstall bool
 	if err != nil && strings.Contains(err.Error(), "release: not found") {
 		if d.isAllowUnreleased() {
-			fmt.Fprintf(os.Stderr, "********************\n\n\tRelease was not present in Helm.  Diff will show entire contents as new.\n\n********************\n")
 			newInstall = true
 			err = nil
 		} else {


### PR DESCRIPTION
If the user explicitly includes the --allow-unreleased flag, we assume they are aware of its implications and will suppress the prompt. If the flag is not included, the prompt will continue to be displayed.