### PR TITLE
refactor(helm3): optimize manifest extraction logic

### DIFF
--- a/cmd/helm3.go
+++ b/cmd/helm3.go
@@ -355,13 +355,21 @@ func extractManifestFromHelmUpgradeDryRunOutput(s []byte, noHooks bool) []byte {
 		return s
 	}
 
+	var (
+		hooks    []byte
+		manifest []byte
+	)
+
 	i := bytes.Index(s, []byte("HOOKS:"))
-	hooks := s[i:]
+	if i > -1 {
+		hooks = s[i:]
+	}
 
 	j := bytes.Index(hooks, []byte("MANIFEST:"))
-
-	manifest := hooks[j:]
-	hooks = hooks[:j]
+	if j > -1 {
+		manifest = hooks[j:]
+		hooks = hooks[:j]
+	}
 
 	k := bytes.Index(manifest, []byte("\nNOTES:"))
 


### PR DESCRIPTION
This pull request refactors the `extractManifestFromHelmUpgradeDryRunOutput` function in `cmd/helm3.go` to improve its handling of edge cases. Specifically, it ensures that the function properly checks for the presence of "HOOKS" and "MANIFEST" sections before attempting to extract them. 

Enhancements to edge case handling:

* [`cmd/helm3.go`](diffhunk://#diff-a0408f7d6a173149c3bcc5a85ae0fd7908f9baf448a1678fa755688373682fceR358-R372): Added conditional checks to verify the existence of "HOOKS" and "MANIFEST" sections before extracting their contents, preventing potential issues with invalid input.