### PR TITLE
chore: update plugin version to 3.12.2

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.12.1"
+version: "3.12.2"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request updates the version of the Helm plugin in the `plugin.yaml` file to reflect the latest release.

Version update:

* [`plugin.yaml`](diffhunk://#diff-d55bf51ed4d80c9c0eef853d64823da5d91fad2e860465f50b40c355fd307afaL4-R4): Updated the `version` field from "3.12.1" to "3.12.2" to indicate the new version of the plugin.