### PR TITLE
build: remove install hooks from release dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ dist: export CGO_ENABLED=0
 dist:
 	rm -rf build/diff/* release/*
 	mkdir -p build/diff/bin release/
-	cp README.md LICENSE plugin.yaml build/diff
+	cp README.md LICENSE build/diff
+	awk '/^hooks:/ { in_hooks = 1; next } in_hooks && /^[^[:space:]]/ { in_hooks = 0 } !in_hooks { print }' plugin.yaml > build/diff/plugin.yaml
 	GOOS=linux GOARCH=amd64 $(GO) build -o build/diff/bin/diff -trimpath -ldflags="$(LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-diff-linux-amd64.tgz diff/
 	GOOS=linux GOARCH=arm64 $(GO) build -o build/diff/bin/diff -trimpath -ldflags="$(LDFLAGS)"


### PR DESCRIPTION
This commit removes the hooks section from plugin.yaml when staging it for release in the dist target, as the script referenced there is not bundled as part of releases, and also not needed.

This fixes #504.

(I hope this Makefile target is actually what you still use to prepare releases, under the release assets there are files like `helm-diff-freebsd-arm64.tgz` that aren't being built here.)