### PR TITLE
build: update Helm version to v3.17.4 and Go to 1.24.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [ default ]
         experimental: [ false ]
-        helm-version: [ v3.18.4, v3.17.3 ]
+        helm-version: [ v3.18.4, v3.17.4 ]
         include:
           - os: windows-latest
             shell: wsl
@@ -61,16 +61,16 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.17.3
+            helm-version: v3.17.4
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.17.3
+            helm-version: v3.17.4
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.17.3
+            helm-version: v3.17.4
 
     steps:
       - name: Disable autocrlf
@@ -111,7 +111,7 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.4
-          - helm-version: v3.17.3
+          - helm-version: v3.17.4
     steps:
       - uses: engineerd/setup-kind@v0.6.2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files to ensure compatibility and maintain up-to-date versions. The most important changes involve updating the Helm version used in CI workflows and bumping the Go version in the `go.mod` file.

### Updates to CI workflows:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL46-R46): Updated the Helm version from `v3.17.3` to `v3.17.4` across all relevant configurations, including the matrix and specific job definitions. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL46-R46) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL64-R73) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL114-R114)

### Dependency updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.24.2` to `1.24.5` to use the latest patch release.