### PR TITLE
build: update plugin version to 3.12.5

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: "diff"
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.12.4"
+version: "3.12.5"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request updates the version of the `diff` plugin in the `plugin.yaml` file.

* Plugin version updated from "3.12.4" to "3.12.5" in `plugin.yaml`.