### PR TITLE
ci: expand workflow trigger to main and master branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - 'main'
+      - 'master'
+  pull_request:
+    branches:
+      - 'main'
+      - 'master'
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the release workflow trigger configuration to also run on pushes and pull requests to the `main` and `master` branches, in addition to tag pushes.

Workflow trigger updates:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR7-R13): Modified the `on:` section to trigger the workflow on pushes to the `main` and `master` branches, as well as on pull requests targeting those branches.