### PR TITLE
build: update helm version to v3.19.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [ default ]
         experimental: [ false ]
-        helm-version: [ v3.18.6, v3.19.0-rc.1 ]
+        helm-version: [ v3.18.6, v3.19.0 ]
         include:
           - os: windows-latest
             shell: wsl
@@ -61,16 +61,16 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.19.0-rc.1
+            helm-version: v3.19.0
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.19.0-rc.1
+            helm-version: v3.19.0
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.19.0-rc.1
+            helm-version: v3.19.0
 
     steps:
       - name: Disable autocrlf
@@ -109,7 +109,7 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.6
-          - helm-version: v3.19.0-rc.1
+          - helm-version: v3.19.0
     steps:
       - uses: engineerd/setup-kind@v0.6.2
         with:


### PR DESCRIPTION
This pull request updates the CI workflow to use the stable release of Helm v3.19.0 instead of the previous release candidate (v3.19.0-rc.1) across all relevant matrix jobs. This ensures that tests run against the latest stable version of Helm, improving reliability and consistency in the CI process.

**CI workflow updates:**

* Updated all Helm version references in the matrix strategy from `v3.19.0-rc.1` to the stable `v3.19.0` in `.github/workflows/ci.yaml` [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL46-R46) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL64-R73) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL112-R112)