### PR TITLE
build: bump version to 3.13.1

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.13.0"
+version: "3.13.1"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request makes a minor update to the `plugin.yaml` file, incrementing the plugin version from "3.13.0" to "3.13.1".