### PR TITLE
Bump helm-diff version to 3.14.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.13.2"
+version: "3.14.0"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request updates the version of the Helm diff plugin to keep it in sync with the latest Helm release.

- Version bump:
  * Updated the `version` field in `plugin.yaml` from `"3.13.2"` to `"3.14.0"` to match the latest Helm release.