### PR TITLE
Fix detailed error codes on Windows

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,13 +7,6 @@ description: "Preview helm upgrade changes as a diff"
 useTunnel: true
 platformCommand:
   - command: ${HELM_PLUGIN_DIR}/bin/diff
-  # powershell does not return the original exit code, while cmd does
-  # see https://github.com/databus23/helm-diff/issues/910
-  - os: windows
-    command: cmd
-    args:
-      - /c
-      - "%HELM_PLUGIN_DIR%/bin/diff"
 
 platformHooks:
   install:


### PR DESCRIPTION
Switches from Powershell to calling the diff.exe directly since Powershell hides the original exit code.

Fixes #910 

Tested locally by editing the plugin.yaml in the plugin directory.