### PR TITLE
bump go version to go 1.25

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,4 +21,4 @@ jobs:
           go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.24.9
+go 1.25
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
This pull request updates the Go toolchain and linter versions to keep the project dependencies current and maintain compatibility with the latest tooling.

Dependency and tooling updates:

* Updated the Go version in `go.mod` from `1.24.9` to `1.25` to use the latest Go release.
* Upgraded the `golangci-lint` GitHub Action version in `.github/workflows/lint.yaml` from `v2.1.6` to `v2.7.2` for improved linting and bug fixes.