### PR TITLE
Update Helm versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [default]
         experimental: [false]
-        helm-version: [v3.18.6, v3.19.2, v4.0.1]
+        helm-version: [v3.18.6, v3.20.0, v4.1.0]
         include:
           - os: windows-latest
             shell: wsl
@@ -58,29 +58,29 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.19.2
+            helm-version: v3.20.0
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.19.2
+            helm-version: v3.20.0
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.19.2
+            helm-version: v3.20.0
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v4.0.1
+            helm-version: v4.1.0
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v4.0.1
+            helm-version: v4.1.0
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v4.0.1
+            helm-version: v4.1.0
 
     steps:
       - name: Disable autocrlf
@@ -119,8 +119,8 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.6
-          - helm-version: v3.19.2
-          - helm-version: v4.0.1
+          - helm-version: v3.20.0
+          - helm-version: v4.1.0
     steps:
       - uses: engineerd/setup-kind@v0.6.2
         with:


### PR DESCRIPTION
Update Helm test matrix to use the latest patch releases:
- v3.19.2 → v3.20.0
- v4.0.1 → v4.1.0

This ensures compatibility testing with the most recent Helm releases.