### PR TITLE
fix: bump go directive to 1.25.7 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.25.0
+go 1.25.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary

- Bump `go` directive in go.mod from 1.25.0 to 1.25.7 to ensure release binaries are compiled with a patched Go toolchain

## Motivation

Go 1.25.0 is affected by several stdlib CVEs including CVE-2025-58183. When `helm plugin install` downloads the pre-built release binary, trivy flags it because the binary embeds the vulnerable Go stdlib. Bumping the go directive ensures the next release is compiled with Go 1.25.7 which includes all patches.

## Test plan

- [x] `go mod tidy` runs clean
- [x] `go build` succeeds
- [x] All tests pass (4/4 packages)