### PR TITLE
pass context to dyff to display the context of changes in multiline diffs

### DIFF
--- a/diff/report.go
+++ b/diff/report.go
@@ -90,7 +90,9 @@ func printDyffReport(r *Report, to io.Writer) {
 		_ = os.Remove(newFile.Name())
 	}()
 
+	context := -1
 	for _, entry := range r.Entries {
+		context = entry.Context
 		_, _ = currentFile.WriteString("---\n")
 		_, _ = newFile.WriteString("---\n")
 		for _, record := range entry.Diffs {
@@ -116,6 +118,11 @@ func printDyffReport(r *Report, to io.Writer) {
 		OmitHeader:           true,
 		MinorChangeThreshold: 0.1,
 	}
+
+	if context != -1 {
+		reportWriter.MultilineContextLines = context
+	}
+
 	_ = reportWriter.WriteReport(to)
 }
 


### PR DESCRIPTION
`dyff` can show context lines of multiline YAML value changes. the helm-diff plugin has context option. With this PR, I propose passing this context option to `dyff` as the `MultilineContextLines` option. This will help betterunderstand what has changed in multiline values.

For example, without passion `MultilineContextLines` I get the following output:
```
spec.configuration
± value change in multiline text (two inserts, two deletions)
-       iteration_interval_ms: 600000
+       iteration_interval_ms: 500000
-     max_bytes_in_batch: 300000
+     max_bytes_in_batch: 400000
```

It looks like one block was changed;  however, I actually modified different part of the multiline value. With passing 3 context lines, the diff looks much clearer:
```
spec.configuration
± value change in multiline text (two inserts, two deletions)
  actor_system_config:
    batch_executor: 2
    executor:

  [59 lines unchanged)]

    bsc_settings:
      cluster_balancing_settings:
        enable: true
-       iteration_interval_ms: 600000
+       iteration_interval_ms: 500000
        max_replicating_pdisks: 10
        max_replicating_vdisks: 10
        prefer_less_occupied_rack: true

  [1550 lines unchanged)]

      max_traces_per_minute: 10
    uploader:
      max_batch_accumulation_milliseconds: 500
-     max_bytes_in_batch: 300000
+     max_bytes_in_batch: 400000
      max_export_requests_inflight: 3
      max_exported_spans_per_second: 3000
      max_spans_in_batch: 500

  [ten lines unchanged)]

        hull_comp_level0_max_ssts_at_once: 2
        hull_comp_sorted_parts_num: 1
      kind: LocalMode
```