### PR TITLE
ci: bump helm to v4.1.1 in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [default]
         experimental: [false]
-        helm-version: [v3.18.6, v3.20.0, v4.1.0]
+        helm-version: [v3.18.6, v3.20.0, v4.1.1]
         include:
           - os: windows-latest
             shell: wsl
@@ -71,16 +71,16 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v4.1.0
+            helm-version: v4.1.1
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v4.1.0
+            helm-version: v4.1.1
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v4.1.0
+            helm-version: v4.1.1
 
     steps:
       - name: Disable autocrlf
@@ -120,7 +120,7 @@ jobs:
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.6
           - helm-version: v3.20.0
-          - helm-version: v4.1.0
+          - helm-version: v4.1.1
     steps:
       - uses: engineerd/setup-kind@v0.6.2
         with:


### PR DESCRIPTION
## Summary
- Bump Helm version from v4.1.0 to v4.1.1 in CI test matrix to align with the dependency version already in go.mod