### PR TITLE
docs: clarify that helm-diff uses helm template by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 This is a Helm plugin giving you a preview of what a `helm upgrade` would change.
 It basically generates a diff between the latest deployed version of a release
-and a `helm upgrade --debug --dry-run`. This can also be used to compare two
-revisions/versions of your helm release.
+and a `helm template`-rendered manifest (or `helm upgrade --dry-run` when `HELM_DIFF_USE_UPGRADE_DRY_RUN=true` is set).
+This can also be used to compare two revisions/versions of your helm release.
 
 <a href="https://asciinema.org/a/105326" target="_blank"><img src="https://asciinema.org/a/105326.png" /></a>
 


### PR DESCRIPTION
## Summary
- Clarifies in the README intro that helm-diff uses `helm template` by default to render manifests
- Notes that `helm upgrade --dry-run` is only used when `HELM_DIFF_USE_UPGRADE_DRY_RUN=true` is set
- Fixes #666

## Context
The original README intro was confusing because it implied `helm upgrade --debug --dry-run` was used by default, but later in the docs it states that `helm template` is the default and `helm upgrade --dry-run` requires setting `HELM_DIFF_USE_UPGRADE_DRY_RUN=true`.

This aligns the intro with the actual code behavior in `cmd/helm.go`:
- Default: `subcmd = "template"` 
- With env var: `subcmd = "upgrade"` with `--dry-run` flag