### PR TITLE
build: bump version to 3.15.4

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.15.3"
+version: "3.15.4"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
This pull request updates the version number of the `diff` Helm plugin to reflect a new release.

- Version update:
  * Bumped the `version` field in `plugin.yaml` from `3.15.3` to `3.15.4` to indicate a new release.