### PR TITLE
fix: support multi-file KUBECONFIG with three-way merge

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -297,11 +298,7 @@ func (d *diffCmd) runHelm3() error {
 	var actionConfig *action.Configuration
 	if d.threeWayMerge || d.takeOwnership {
 		actionConfig = new(action.Configuration)
-		localEnv := cli.New()
-		*localEnv = *envSettings
-		if d.kubeContext != "" {
-			localEnv.KubeContext = d.kubeContext
-		}
+		localEnv := prepareEnvSettings(d.kubeContext)
 		if err := actionConfig.Init(localEnv.RESTClientGetter(), localEnv.Namespace(), os.Getenv("HELM_DRIVER")); err != nil {
 			log.Fatalf("%+v", err)
 		}
@@ -408,4 +405,15 @@ func checkOwnership(d *diffCmd, resources kube.ResourceList, currentSpecs map[st
 		return nil
 	})
 	return newOwnedReleases, err
+}
+
+func prepareEnvSettings(kubeContext string) *cli.EnvSettings {
+	localEnv := cli.New()
+	if len(filepath.SplitList(localEnv.KubeConfig)) > 1 {
+		localEnv.KubeConfig = ""
+	}
+	if kubeContext != "" {
+		localEnv.KubeContext = kubeContext
+	}
+	return localEnv
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -113,8 +113,6 @@ This can be used to visualize what changes a helm upgrade will
 perform.
 `
 
-var envSettings = cli.New()
-
 func newChartCommand() *cobra.Command {
 	diff := diffCmd{
 		namespace: os.Getenv("HELM_NAMESPACE"),

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -62,4 +64,120 @@ func TestIsRemoteAccessAllowed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareEnvSettings_MultiFileKubeconfig(t *testing.T) {
+	original := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", original)
+
+	cases := []struct {
+		name            string
+		kubeconfig      string
+		kubeContext     string
+		wantKubeConfig  string
+		wantKubeContext string
+	}{
+		{
+			name:            "single file kubeconfig is preserved",
+			kubeconfig:      "/path/to/config",
+			kubeContext:     "",
+			wantKubeConfig:  "/path/to/config",
+			wantKubeContext: "",
+		},
+		{
+			name:            "multi-file kubeconfig is cleared",
+			kubeconfig:      "/path/to/file1" + string(filepath.ListSeparator) + "/path/to/file2",
+			kubeContext:     "",
+			wantKubeConfig:  "",
+			wantKubeContext: "",
+		},
+		{
+			name:            "multi-file kubeconfig with three files is cleared",
+			kubeconfig:      "/a" + string(filepath.ListSeparator) + "/b" + string(filepath.ListSeparator) + "/c",
+			kubeContext:     "",
+			wantKubeConfig:  "",
+			wantKubeContext: "",
+		},
+		{
+			name:            "empty kubeconfig is preserved",
+			kubeconfig:      "",
+			kubeContext:     "",
+			wantKubeConfig:  "",
+			wantKubeContext: "",
+		},
+		{
+			name:            "kube-context override is applied",
+			kubeconfig:      "/path/to/config",
+			kubeContext:     "my-context",
+			wantKubeConfig:  "/path/to/config",
+			wantKubeContext: "my-context",
+		},
+		{
+			name:            "multi-file kubeconfig with kube-context override",
+			kubeconfig:      "/path/to/file1" + string(filepath.ListSeparator) + "/path/to/file2",
+			kubeContext:     "my-context",
+			wantKubeConfig:  "",
+			wantKubeContext: "my-context",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("KUBECONFIG", tc.kubeconfig)
+
+			env := prepareEnvSettings(tc.kubeContext)
+
+			if env.KubeConfig != tc.wantKubeConfig {
+				t.Errorf("KubeConfig: got %q, want %q", env.KubeConfig, tc.wantKubeConfig)
+			}
+			if env.KubeContext != tc.wantKubeContext {
+				t.Errorf("KubeContext: got %q, want %q", env.KubeContext, tc.wantKubeContext)
+			}
+		})
+	}
+}
+
+func TestPrepareEnvSettings_ConfigFlagsPointToCorrectFields(t *testing.T) {
+	original := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", original)
+
+	t.Run("config flags reflect kube-context override", func(t *testing.T) {
+		os.Setenv("KUBECONFIG", "/some/config")
+		env := prepareEnvSettings("my-override-context")
+
+		if env.KubeContext != "my-override-context" {
+			t.Errorf("env.KubeContext = %q, want %q", env.KubeContext, "my-override-context")
+		}
+	})
+
+	t.Run("multi-file kubeconfig does not set ExplicitPath", func(t *testing.T) {
+		multiPath := "/tmp/file1" + string(filepath.ListSeparator) + "/tmp/file2"
+		os.Setenv("KUBECONFIG", multiPath)
+
+		env := prepareEnvSettings("")
+
+		if env.KubeConfig != "" {
+			t.Errorf("env.KubeConfig = %q, want empty string for multi-file KUBECONFIG", env.KubeConfig)
+		}
+
+		getter := env.RESTClientGetter()
+		rawConfig := getter.ToRawKubeConfigLoader()
+		loadingRules := rawConfig.ConfigAccess()
+
+		if loadingRules != nil {
+			if explicitPath := loadingRules.GetExplicitFile(); explicitPath != "" {
+				t.Errorf("ExplicitPath = %q, want empty string for multi-file KUBECONFIG", explicitPath)
+			}
+		}
+	})
+
+	t.Run("single file kubeconfig preserves ExplicitPath", func(t *testing.T) {
+		os.Setenv("KUBECONFIG", "/tmp/single-config")
+
+		env := prepareEnvSettings("")
+
+		if env.KubeConfig != "/tmp/single-config" {
+			t.Errorf("env.KubeConfig = %q, want %q", env.KubeConfig, "/tmp/single-config")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #969

Multi-file `KUBECONFIG` (e.g., `KUBECONFIG=/path/a:/path/b:/path/c`) failed with `HELM_DIFF_THREE_WAY_MERGE=true` due to the entire colon-separated string being passed as `ExplicitPath` to the k8s client config loader, which called `os.Stat()` on the unsplit path.

- Extracted `prepareEnvSettings()` helper that creates a fresh `EnvSettings` and clears `KubeConfig` when it contains multiple paths, allowing the default loading rules to handle multi-file KUBECONFIG via the `Precedence` field
- This also fixes the `--kube-context` flag being silently ignored in the three-way merge path (the previous shallow copy `*localEnv = *envSettings` left `ConfigFlags.Context` pointing to the wrong struct)
- Added 9 test cases covering single/multi-file KUBECONFIG, kube-context overrides, and ExplicitPath verification