### PR TITLE
feat: add local subcommand to compare two chart folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Usage:
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
+  local       Shows diff between two local chart directories
   release     Shows diff between release's manifests
   revision    Shows diff between revision's manifests
   rollback    Show a diff explaining what a helm rollback could perform
@@ -173,6 +174,63 @@ helm diff upgrade prod api ./charts/api --output structured
 When a kind is suppressed via `--suppress`, `changesSuppressed` is set to `true` and field details are omitted. Nested metadata such as labels show the container path (`metadata.labels`) and expose the label key through the `field` property (for example `app.kubernetes.io/version`).
 
 ## Commands:
+
+### local:
+
+```
+$ helm diff local -h
+
+This command compares the manifests of two local chart directories.
+
+It renders both charts using 'helm template' and shows the differences
+between the resulting manifests.
+
+This is useful for:
+ - Comparing different versions of a chart
+ - Previewing changes before committing
+ - Validating chart modifications
+
+Usage:
+  diff local [flags] CHART1 CHART2
+
+Examples:
+  helm diff local ./chart-v1 ./chart-v2
+  helm diff local ./chart-v1 ./chart-v2 -f values.yaml
+  helm diff local /path/to/chart-a /path/to/chart-b --set replicas=3
+
+Flags:
+  -a, --api-versions stringArray                 Kubernetes api versions used for Capabilities.APIVersions
+  -C, --context int                              output NUM lines of context around changes (default -1)
+      --detailed-exitcode                        return a non-zero exit code when there are changes
+      --enable-dns                               enable DNS lookups when rendering templates
+  -D, --find-renames float32                     Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
+  -h, --help                                     help for local
+      --include-crds                             include CRDs in the diffing
+      --include-tests                            enable the diffing of the helm test hooks
+      --kube-version string                      Kubernetes version used for Capabilities.KubeVersion
+      --namespace string                         namespace to use for template rendering
+      --normalize-manifests                      normalize manifests before running diff to exclude style differences from the output
+      --output string                            Possible values: diff, simple, template, dyff. When set to "template", use the env var HELM_DIFF_TPL to specify the template. (default "diff")
+      --post-renderer string                     the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path
+      --post-renderer-args stringArray           an argument to the post-renderer (can specify multiple)
+      --release string                           release name to use for template rendering (default "release")
+      --set stringArray                          set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --set-file stringArray                     set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --set-json stringArray                     set JSON values on the command line (can specify multiple or separate values with commas: key1=jsonval1,key2=jsonval2)
+      --set-literal stringArray                  set STRING literal values on the command line
+      --set-string stringArray                   set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --show-secrets                             do not redact secret values in the output
+      --show-secrets-decoded                     decode secret values in the output
+      --strip-trailing-cr                        strip trailing carriage return on input
+      --suppress stringArray                     allows suppression of the kinds listed in the diff output (can specify multiple, like '--suppress Deployment --suppress Service')
+      --suppress-output-line-regex stringArray   a regex to suppress diff output lines that match
+  -q, --suppress-secrets                         suppress secrets in the output
+  -f, --values valueFiles                        specify values in a YAML file (can specify multiple) (default [])
+
+Global Flags:
+      --color      color output. You can control the value for this flag via HELM_DIFF_COLOR=[true|false]. If both --no-color and --color are unspecified, coloring enabled only when the stdout is a term and TERM is not "dumb"
+      --no-color   remove colors from the output. If both --no-color and --color are unspecified, coloring enabled only when the stdout is a term and TERM is not "dumb"
+```
 
 ### upgrade:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Flags:
       --kube-version string                      Kubernetes version used for Capabilities.KubeVersion
       --namespace string                         namespace to use for template rendering
       --normalize-manifests                      normalize manifests before running diff to exclude style differences from the output
-      --output string                            Possible values: diff, simple, template, dyff. When set to "template", use the env var HELM_DIFF_TPL to specify the template. (default "diff")
+      --output string                            Possible values: diff, simple, template, json, structured, dyff. When set to "template", use the env var HELM_DIFF_TPL to specify the template. (default "diff")
       --post-renderer string                     the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path
       --post-renderer-args stringArray           an argument to the post-renderer (can specify multiple)
       --release string                           release name to use for template rendering (default "release")

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -15,25 +15,25 @@ import (
 )
 
 type local struct {
-	chart1             string
-	chart2             string
-	release            string
-	namespace          string
-	detailedExitCode   bool
-	includeTests       bool
-	includeCRDs        bool
-	normalizeManifests bool
-	enableDNS          bool
-	valueFiles         valueFiles
-	values             []string
-	stringValues       []string
+	chart1              string
+	chart2              string
+	release             string
+	namespace           string
+	detailedExitCode    bool
+	includeTests        bool
+	includeCRDs         bool
+	normalizeManifests  bool
+	enableDNS           bool
+	valueFiles          valueFiles
+	values              []string
+	stringValues        []string
 	stringLiteralValues []string
-	jsonValues         []string
-	fileValues         []string
-	postRenderer       string
-	postRendererArgs   []string
-	extraAPIs          []string
-	kubeVersion        string
+	jsonValues          []string
+	fileValues          []string
+	postRenderer        string
+	postRendererArgs    []string
+	extraAPIs           []string
+	kubeVersion         string
 	diff.Options
 }
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/databus23/helm-diff/v3/diff"
+	"github.com/databus23/helm-diff/v3/manifest"
+)
+
+type local struct {
+	chart1             string
+	chart2             string
+	release            string
+	namespace          string
+	detailedExitCode   bool
+	includeTests       bool
+	includeCRDs        bool
+	normalizeManifests bool
+	enableDNS          bool
+	valueFiles         valueFiles
+	values             []string
+	stringValues       []string
+	stringLiteralValues []string
+	jsonValues         []string
+	fileValues         []string
+	postRenderer       string
+	postRendererArgs   []string
+	extraAPIs          []string
+	kubeVersion        string
+	diff.Options
+}
+
+const localCmdLongUsage = `
+This command compares the manifests of two local chart directories.
+
+It renders both charts using 'helm template' and shows the differences
+between the resulting manifests.
+
+This is useful for:
+ - Comparing different versions of a chart
+ - Previewing changes before committing
+ - Validating chart modifications
+`
+
+func localCmd() *cobra.Command {
+	diff := local{
+		release: "release",
+	}
+
+	localCmd := &cobra.Command{
+		Use:   "local [flags] CHART1 CHART2",
+		Short: "Shows diff between two local chart directories",
+		Long:  localCmdLongUsage,
+		Example: strings.Join([]string{
+			"  helm diff local ./chart-v1 ./chart-v2",
+			"  helm diff local ./chart-v1 ./chart-v2 -f values.yaml",
+			"  helm diff local /path/to/chart-a /path/to/chart-b --set replicas=3",
+		}, "\n"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Suppress the command usage on error. See #77 for more info
+			cmd.SilenceUsage = true
+
+			if v, _ := cmd.Flags().GetBool("version"); v {
+				fmt.Println(Version)
+				return nil
+			}
+
+			if err := checkArgsLength(len(args), "chart1 path", "chart2 path"); err != nil {
+				return err
+			}
+
+			ProcessDiffOptions(cmd.Flags(), &diff.Options)
+
+			diff.chart1 = args[0]
+			diff.chart2 = args[1]
+
+			if diff.namespace == "" {
+				diff.namespace = os.Getenv("HELM_NAMESPACE")
+			}
+
+			return diff.run()
+		},
+	}
+
+	localCmd.Flags().StringVar(&diff.release, "release", "release", "release name to use for template rendering")
+	localCmd.Flags().StringVar(&diff.namespace, "namespace", "", "namespace to use for template rendering")
+	localCmd.Flags().BoolVar(&diff.detailedExitCode, "detailed-exitcode", false, "return a non-zero exit code when there are changes")
+	localCmd.Flags().BoolVar(&diff.includeTests, "include-tests", false, "enable the diffing of the helm test hooks")
+	localCmd.Flags().BoolVar(&diff.includeCRDs, "include-crds", false, "include CRDs in the diffing")
+	localCmd.Flags().BoolVar(&diff.normalizeManifests, "normalize-manifests", false, "normalize manifests before running diff to exclude style differences from the output")
+	localCmd.Flags().BoolVar(&diff.enableDNS, "enable-dns", false, "enable DNS lookups when rendering templates")
+	localCmd.Flags().VarP(&diff.valueFiles, "values", "f", "specify values in a YAML file (can specify multiple)")
+	localCmd.Flags().StringArrayVar(&diff.values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	localCmd.Flags().StringArrayVar(&diff.stringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	localCmd.Flags().StringArrayVar(&diff.stringLiteralValues, "set-literal", []string{}, "set STRING literal values on the command line")
+	localCmd.Flags().StringArrayVar(&diff.jsonValues, "set-json", []string{}, "set JSON values on the command line (can specify multiple or separate values with commas: key1=jsonval1,key2=jsonval2)")
+	localCmd.Flags().StringArrayVar(&diff.fileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
+	localCmd.Flags().StringVar(&diff.postRenderer, "post-renderer", "", "the path to an executable to be used for post rendering. If it exists in $PATH, the binary will be used, otherwise it will try to look for the executable at the given path")
+	localCmd.Flags().StringArrayVar(&diff.postRendererArgs, "post-renderer-args", []string{}, "an argument to the post-renderer (can specify multiple)")
+	localCmd.Flags().StringArrayVarP(&diff.extraAPIs, "api-versions", "a", []string{}, "Kubernetes api versions used for Capabilities.APIVersions")
+	localCmd.Flags().StringVar(&diff.kubeVersion, "kube-version", "", "Kubernetes version used for Capabilities.KubeVersion")
+
+	AddDiffOptions(localCmd.Flags(), &diff.Options)
+
+	localCmd.SuggestionsMinimumDistance = 1
+
+	return localCmd
+}
+
+func (l *local) run() error {
+	manifest1, err := l.renderChart(l.chart1)
+	if err != nil {
+		return fmt.Errorf("Failed to render chart %s: %w", l.chart1, err)
+	}
+
+	manifest2, err := l.renderChart(l.chart2)
+	if err != nil {
+		return fmt.Errorf("Failed to render chart %s: %w", l.chart2, err)
+	}
+
+	excludes := []string{manifest.Helm3TestHook, manifest.Helm2TestSuccessHook}
+	if l.includeTests {
+		excludes = []string{}
+	}
+
+	specs1 := manifest.Parse(string(manifest1), l.namespace, l.normalizeManifests, excludes...)
+	specs2 := manifest.Parse(string(manifest2), l.namespace, l.normalizeManifests, excludes...)
+
+	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
+
+	if l.detailedExitCode && seenAnyChanges {
+		return Error{
+			error: errors.New("identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)"),
+			Code:  2,
+		}
+	}
+
+	return nil
+}
+
+func (l *local) renderChart(chartPath string) ([]byte, error) {
+	flags := []string{}
+
+	if l.includeCRDs {
+		flags = append(flags, "--include-crds")
+	}
+
+	if l.namespace != "" {
+		flags = append(flags, "--namespace", l.namespace)
+	}
+
+	if l.postRenderer != "" {
+		flags = append(flags, "--post-renderer", l.postRenderer)
+	}
+
+	for _, arg := range l.postRendererArgs {
+		flags = append(flags, "--post-renderer-args", arg)
+	}
+
+	for _, valueFile := range l.valueFiles {
+		if strings.TrimSpace(valueFile) == "-" {
+			bytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+
+			tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
+			if err != nil {
+				return nil, err
+			}
+			defer func() {
+				_ = os.Remove(tmpfile.Name())
+			}()
+
+			if _, err := tmpfile.Write(bytes); err != nil {
+				_ = tmpfile.Close()
+				return nil, err
+			}
+
+			if err := tmpfile.Close(); err != nil {
+				return nil, err
+			}
+
+			flags = append(flags, "--values", tmpfile.Name())
+		} else {
+			flags = append(flags, "--values", valueFile)
+		}
+	}
+
+	for _, value := range l.values {
+		flags = append(flags, "--set", value)
+	}
+
+	for _, stringValue := range l.stringValues {
+		flags = append(flags, "--set-string", stringValue)
+	}
+
+	for _, stringLiteralValue := range l.stringLiteralValues {
+		flags = append(flags, "--set-literal", stringLiteralValue)
+	}
+
+	for _, jsonValue := range l.jsonValues {
+		flags = append(flags, "--set-json", jsonValue)
+	}
+
+	for _, fileValue := range l.fileValues {
+		flags = append(flags, "--set-file", fileValue)
+	}
+
+	if l.enableDNS {
+		flags = append(flags, "--enable-dns")
+	}
+
+	for _, a := range l.extraAPIs {
+		flags = append(flags, "--api-versions", a)
+	}
+
+	if l.kubeVersion != "" {
+		flags = append(flags, "--kube-version", l.kubeVersion)
+	}
+
+	args := []string{"template", l.release, chartPath}
+	args = append(args, flags...)
+
+	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	return outputWithRichError(cmd)
+}

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -134,8 +134,8 @@ func (l *local) run() error {
 		excludes = []string{}
 	}
 
-	specs1 := manifest.Parse(string(manifest1), l.namespace, l.normalizeManifests, excludes...)
-	specs2 := manifest.Parse(string(manifest2), l.namespace, l.normalizeManifests, excludes...)
+	specs1 := manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
+	specs2 := manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
 
 	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -117,25 +117,23 @@ func (l *local) run() error {
 		defer cleanup()
 	}
 
-	manifest1, err := l.renderChart(l.chart1)
-	if err != nil {
-		return fmt.Errorf("failed to render chart %q: %w", l.chart1, err)
-	}
-
-	manifest2, err := l.renderChart(l.chart2)
-	if err != nil {
-		return fmt.Errorf("failed to render chart %q: %w", l.chart2, err)
-	}
-
 	excludes := []string{manifest.Helm3TestHook, manifest.Helm2TestSuccessHook}
 	if l.includeTests {
 		excludes = []string{}
 	}
 
+	manifest1, err := l.renderChart(l.chart1)
+	if err != nil {
+		return fmt.Errorf("failed to render chart %q: %w", l.chart1, err)
+	}
 	specs1 := manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
+	manifest1 = nil //nolint:ineffassign // nil to allow GC to reclaim raw bytes before rendering the second chart
+
+	manifest2, err := l.renderChart(l.chart2)
+	if err != nil {
+		return fmt.Errorf("failed to render chart %q: %w", l.chart2, err)
+	}
 	specs2 := manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
-	manifest1 = nil //nolint:ineffassign // nil to allow GC to reclaim raw bytes before diff computation
-	manifest2 = nil //nolint:ineffassign // nil to allow GC to reclaim raw bytes before diff computation
 
 	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -132,10 +132,13 @@ func (l *local) run() error {
 		excludes = []string{}
 	}
 
-	specs1 := manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
-	specs2 := manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
-	manifest1 = nil
-	manifest2 = nil
+	var specs1, specs2 map[string]*manifest.MappingResult
+	func() {
+		specs1 = manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
+		specs2 = manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
+		manifest1 = nil
+		manifest2 = nil
+	}()
 
 	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -64,13 +64,7 @@ func localCmd() *cobra.Command {
 			"  helm diff local /path/to/chart-a /path/to/chart-b --set replicas=3",
 		}, "\n"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Suppress the command usage on error. See #77 for more info
 			cmd.SilenceUsage = true
-
-			if v, _ := cmd.Flags().GetBool("version"); v {
-				fmt.Println(Version)
-				return nil
-			}
 
 			if err := checkArgsLength(len(args), "chart1 path", "chart2 path"); err != nil {
 				return err
@@ -154,31 +148,39 @@ func (l *local) run() error {
 }
 
 func (l *local) prepareStdinValues() (func(), error) {
+	var name string
+
 	for i, valueFile := range l.valueFiles {
 		if strings.TrimSpace(valueFile) == "-" {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return nil, err
+			if name == "" {
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return nil, err
+				}
+
+				tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
+				if err != nil {
+					return nil, err
+				}
+
+				if _, err := tmpfile.Write(data); err != nil {
+					_ = tmpfile.Close()
+					return nil, err
+				}
+
+				if err := tmpfile.Close(); err != nil {
+					return nil, err
+				}
+
+				name = tmpfile.Name()
 			}
 
-			tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
-			if err != nil {
-				return nil, err
-			}
-
-			if _, err := tmpfile.Write(data); err != nil {
-				_ = tmpfile.Close()
-				return nil, err
-			}
-
-			if err := tmpfile.Close(); err != nil {
-				return nil, err
-			}
-
-			l.valueFiles[i] = tmpfile.Name()
-			name := tmpfile.Name()
-			return func() { _ = os.Remove(name) }, nil
+			l.valueFiles[i] = name
 		}
+	}
+
+	if name != "" {
+		return func() { _ = os.Remove(name) }, nil
 	}
 	return nil, nil
 }

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -161,10 +161,10 @@ func (l *local) prepareStdinValues() error {
 			if err != nil {
 				return err
 			}
-			defer os.Remove(tmpfile.Name())
+			defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 			if _, err := tmpfile.Write(data); err != nil {
-				tmpfile.Close()
+				_ = tmpfile.Close()
 				return err
 			}
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -115,14 +115,18 @@ func localCmd() *cobra.Command {
 }
 
 func (l *local) run() error {
+	if err := l.prepareStdinValues(); err != nil {
+		return err
+	}
+
 	manifest1, err := l.renderChart(l.chart1)
 	if err != nil {
-		return fmt.Errorf("Failed to render chart %s: %w", l.chart1, err)
+		return fmt.Errorf("failed to render chart %s: %w", l.chart1, err)
 	}
 
 	manifest2, err := l.renderChart(l.chart2)
 	if err != nil {
-		return fmt.Errorf("Failed to render chart %s: %w", l.chart2, err)
+		return fmt.Errorf("failed to render chart %s: %w", l.chart2, err)
 	}
 
 	excludes := []string{manifest.Helm3TestHook, manifest.Helm2TestSuccessHook}
@@ -142,6 +146,36 @@ func (l *local) run() error {
 		}
 	}
 
+	return nil
+}
+
+func (l *local) prepareStdinValues() error {
+	for i, valueFile := range l.valueFiles {
+		if strings.TrimSpace(valueFile) == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+
+			tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
+			if err != nil {
+				return err
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write(data); err != nil {
+				tmpfile.Close()
+				return err
+			}
+
+			if err := tmpfile.Close(); err != nil {
+				return err
+			}
+
+			l.valueFiles[i] = tmpfile.Name()
+			break
+		}
+	}
 	return nil
 }
 
@@ -165,33 +199,7 @@ func (l *local) renderChart(chartPath string) ([]byte, error) {
 	}
 
 	for _, valueFile := range l.valueFiles {
-		if strings.TrimSpace(valueFile) == "-" {
-			bytes, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return nil, err
-			}
-
-			tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
-			if err != nil {
-				return nil, err
-			}
-			defer func() {
-				_ = os.Remove(tmpfile.Name())
-			}()
-
-			if _, err := tmpfile.Write(bytes); err != nil {
-				_ = tmpfile.Close()
-				return nil, err
-			}
-
-			if err := tmpfile.Close(); err != nil {
-				return nil, err
-			}
-
-			flags = append(flags, "--values", tmpfile.Name())
-		} else {
-			flags = append(flags, "--values", valueFile)
-		}
+		flags = append(flags, "--values", valueFile)
 	}
 
 	for _, value := range l.values {
@@ -229,6 +237,10 @@ func (l *local) renderChart(chartPath string) ([]byte, error) {
 	args := []string{"template", l.release, chartPath}
 	args = append(args, flags...)
 
-	cmd := exec.Command(os.Getenv("HELM_BIN"), args...)
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	cmd := exec.Command(helmBin, args...)
 	return outputWithRichError(cmd)
 }

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -119,12 +119,12 @@ func (l *local) run() error {
 
 	manifest1, err := l.renderChart(l.chart1)
 	if err != nil {
-		return fmt.Errorf("failed to render chart %s: %w", l.chart1, err)
+		return fmt.Errorf("failed to render chart %q: %w", l.chart1, err)
 	}
 
 	manifest2, err := l.renderChart(l.chart2)
 	if err != nil {
-		return fmt.Errorf("failed to render chart %s: %w", l.chart2, err)
+		return fmt.Errorf("failed to render chart %q: %w", l.chart2, err)
 	}
 
 	excludes := []string{manifest.Helm3TestHook, manifest.Helm2TestSuccessHook}
@@ -134,6 +134,8 @@ func (l *local) run() error {
 
 	specs1 := manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
 	specs2 := manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
+	manifest1 = nil
+	manifest2 = nil
 
 	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
 
@@ -165,10 +167,12 @@ func (l *local) prepareStdinValues() (func(), error) {
 
 				if _, err := tmpfile.Write(data); err != nil {
 					_ = tmpfile.Close()
+					_ = os.Remove(tmpfile.Name())
 					return nil, err
 				}
 
 				if err := tmpfile.Close(); err != nil {
+					_ = os.Remove(tmpfile.Name())
 					return nil, err
 				}
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -132,13 +132,10 @@ func (l *local) run() error {
 		excludes = []string{}
 	}
 
-	var specs1, specs2 map[string]*manifest.MappingResult
-	func() {
-		specs1 = manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
-		specs2 = manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
-		manifest1 = nil
-		manifest2 = nil
-	}()
+	specs1 := manifest.Parse(manifest1, l.namespace, l.normalizeManifests, excludes...)
+	specs2 := manifest.Parse(manifest2, l.namespace, l.normalizeManifests, excludes...)
+	manifest1 = nil //nolint:ineffassign // nil to allow GC to reclaim raw bytes before diff computation
+	manifest2 = nil //nolint:ineffassign // nil to allow GC to reclaim raw bytes before diff computation
 
 	seenAnyChanges := diff.Manifests(specs1, specs2, &l.Options, os.Stdout)
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -115,8 +115,12 @@ func localCmd() *cobra.Command {
 }
 
 func (l *local) run() error {
-	if err := l.prepareStdinValues(); err != nil {
+	cleanup, err := l.prepareStdinValues()
+	if err != nil {
 		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
 	}
 
 	manifest1, err := l.renderChart(l.chart1)
@@ -149,34 +153,34 @@ func (l *local) run() error {
 	return nil
 }
 
-func (l *local) prepareStdinValues() error {
+func (l *local) prepareStdinValues() (func(), error) {
 	for i, valueFile := range l.valueFiles {
 		if strings.TrimSpace(valueFile) == "-" {
 			data, err := io.ReadAll(os.Stdin)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			tmpfile, err := os.CreateTemp("", "helm-diff-stdin-values")
 			if err != nil {
-				return err
+				return nil, err
 			}
-			defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 			if _, err := tmpfile.Write(data); err != nil {
 				_ = tmpfile.Close()
-				return err
+				return nil, err
 			}
 
 			if err := tmpfile.Close(); err != nil {
-				return err
+				return nil, err
 			}
 
 			l.valueFiles[i] = tmpfile.Name()
-			break
+			name := tmpfile.Name()
+			return func() { _ = os.Remove(name) }, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (l *local) renderChart(chartPath string) ([]byte, error) {

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLocalCmdArgValidation(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name:        "no arguments",
+			args:        []string{},
+			expectError: true,
+		},
+		{
+			name:        "one argument",
+			args:        []string{"chart1"},
+			expectError: true,
+		},
+		{
+			name:        "three arguments",
+			args:        []string{"chart1", "chart2", "chart3"},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := localCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+
+			if tc.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLocalCmdExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+	manifestYAML := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value
+`
+
+	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
+cat <<EOF
+`+manifestYAML+`
+EOF
+`), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2})
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+}
+

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -79,4 +79,3 @@ EOF
 		t.Errorf("Expected no error but got: %v", err)
 	}
 }
-

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -48,8 +48,6 @@ func TestLocalCmdArgValidation(t *testing.T) {
 }
 
 func TestLocalCmdExecution(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
 	manifestYAML := `---
 apiVersion: v1
 kind: ConfigMap
@@ -59,17 +57,7 @@ metadata:
 data:
   key: value
 `
-
-	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
-cat <<EOF
-`+manifestYAML+`
-EOF
-`), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelm(t, "default", manifestYAML, "", "")
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -77,15 +65,13 @@ EOF
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Errorf("Expected no error but got: %v", err)
 	}
 }
 
 func TestLocalCmdNoChanges(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
 	manifestYAML := `---
 apiVersion: v1
 kind: ConfigMap
@@ -95,16 +81,7 @@ metadata:
 data:
   key: value
 `
-	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
-cat <<'EOF'
-`+manifestYAML+`
-EOF
-`), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelm(t, "default", manifestYAML, "", "")
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -116,7 +93,7 @@ EOF
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	w.Close()
 	os.Stdout = oldStdout
 
@@ -132,9 +109,6 @@ EOF
 }
 
 func TestLocalCmdWithChanges(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
-
 	manifest1 := `---
 apiVersion: v1
 kind: ConfigMap
@@ -153,28 +127,7 @@ metadata:
 data:
   key: value2
 `
-
-	script := `#!/bin/sh
-CALL_COUNT="` + tmpDir + `/call_count"
-COUNT=$(cat "$CALL_COUNT" 2>/dev/null || echo "0")
-COUNT=$((COUNT + 1))
-echo "$COUNT" > "$CALL_COUNT"
-if [ "$COUNT" = "1" ]; then
-cat <<'MANIFEST1'
-` + manifest1 + `
-MANIFEST1
-else
-cat <<'MANIFEST2'
-` + manifest2 + `
-MANIFEST2
-fi
-`
-	err := os.WriteFile(fakeHelm, []byte(script), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelmDual(t, manifest1, manifest2)
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -186,7 +139,7 @@ fi
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	w.Close()
 	os.Stdout = oldStdout
 
@@ -204,9 +157,6 @@ fi
 }
 
 func TestLocalCmdDetailedExitCode(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
-
 	manifest1 := `---
 apiVersion: v1
 kind: ConfigMap
@@ -225,28 +175,7 @@ metadata:
 data:
   key: value2
 `
-
-	script := `#!/bin/sh
-CALL_COUNT="` + tmpDir + `/call_count"
-COUNT=$(cat "$CALL_COUNT" 2>/dev/null || echo "0")
-COUNT=$((COUNT + 1))
-echo "$COUNT" > "$CALL_COUNT"
-if [ "$COUNT" = "1" ]; then
-cat <<'MANIFEST1'
-` + manifest1 + `
-MANIFEST1
-else
-cat <<'MANIFEST2'
-` + manifest2 + `
-MANIFEST2
-fi
-`
-	err := os.WriteFile(fakeHelm, []byte(script), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelmDual(t, manifest1, manifest2)
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -254,7 +183,7 @@ fi
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2, "--detailed-exitcode"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("Expected error with exit code 2 but got nil")
 	}
@@ -269,8 +198,6 @@ fi
 }
 
 func TestLocalCmdDetailedExitCodeNoChanges(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
 	manifestYAML := `---
 apiVersion: v1
 kind: ConfigMap
@@ -280,16 +207,7 @@ metadata:
 data:
   key: value
 `
-	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
-cat <<'EOF'
-`+manifestYAML+`
-EOF
-`), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelm(t, "default", manifestYAML, "", "")
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -297,34 +215,23 @@ EOF
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2, "--detailed-exitcode"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Errorf("Expected no error when no changes, but got: %v", err)
 	}
 }
 
 func TestLocalCmdNamespace(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
-
-	script := `#!/bin/sh
-echo "$@" > ` + tmpDir + `/args
-cat <<'EOF'
----
+	manifestYAML := `---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-config
 data:
   key: value
-EOF
 `
-	err := os.WriteFile(fakeHelm, []byte(script), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	argsFile := t.TempDir() + "/args"
+	setupFakeHelm(t, "capture_args", manifestYAML, argsFile, "")
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -332,31 +239,19 @@ EOF
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2, "--namespace", "myns"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("Expected no error but got: %v", err)
 	}
 
-	args1, _ := os.ReadFile(tmpDir + "/args")
+	args1, _ := os.ReadFile(argsFile)
 	if !strings.Contains(string(args1), "--namespace myns") {
 		t.Errorf("Expected --namespace myns in helm template args, got: %q", string(args1))
 	}
 }
 
 func TestLocalCmdHelmTemplateError(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeHelm := tmpDir + "/helm"
-
-	script := `#!/bin/sh
-echo "error: chart not found" >&2
-exit 1
-`
-	err := os.WriteFile(fakeHelm, []byte(script), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("HELM_BIN", fakeHelm)
+	setupFakeHelm(t, "error", "", "", "")
 
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
@@ -364,8 +259,30 @@ exit 1
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("Expected error when helm template fails but got nil")
 	}
+}
+
+func setupFakeHelm(t *testing.T, mode, output, argsFile, countFile string) {
+	t.Helper()
+	t.Setenv("HELM_DIFF_FAKE_HELM", "1")
+	t.Setenv("HELM_DIFF_FAKE_HELM_MODE", mode)
+	t.Setenv("HELM_DIFF_FAKE_OUTPUT", output)
+	t.Setenv("HELM_DIFF_FAKE_ARGS_FILE", argsFile)
+	t.Setenv("HELM_DIFF_FAKE_COUNT_FILE", countFile)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HELM_BIN", exe)
+}
+
+func setupFakeHelmDual(t *testing.T, manifest1, manifest2 string) {
+	t.Helper()
+	countFile := t.TempDir() + "/call_count"
+	setupFakeHelm(t, "dual", "", "", countFile)
+	t.Setenv("HELM_DIFF_FAKE_OUTPUT_1", manifest1)
+	t.Setenv("HELM_DIFF_FAKE_OUTPUT_2", manifest2)
 }

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -77,5 +79,292 @@ EOF
 	err = cmd.Execute()
 	if err != nil {
 		t.Errorf("Expected no error but got: %v", err)
+	}
+}
+
+func TestLocalCmdNoChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+	manifestYAML := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value
+`
+	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
+cat <<'EOF'
+`+manifestYAML+`
+EOF
+`), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2})
+
+	err = cmd.Execute()
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	if buf.String() != "" {
+		t.Errorf("Expected no output when charts are identical, got: %q", buf.String())
+	}
+}
+
+func TestLocalCmdWithChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+
+	manifest1 := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value1
+`
+	manifest2 := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value2
+`
+
+	script := `#!/bin/sh
+CALL_COUNT="` + tmpDir + `/call_count"
+COUNT=$(cat "$CALL_COUNT" 2>/dev/null || echo "0")
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$CALL_COUNT"
+if [ "$COUNT" = "1" ]; then
+cat <<'MANIFEST1'
+` + manifest1 + `
+MANIFEST1
+else
+cat <<'MANIFEST2'
+` + manifest2 + `
+MANIFEST2
+fi
+`
+	err := os.WriteFile(fakeHelm, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2})
+
+	err = cmd.Execute()
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "value1") || !strings.Contains(output, "value2") {
+		t.Errorf("Expected diff output containing value1 and value2, got: %q", output)
+	}
+}
+
+func TestLocalCmdDetailedExitCode(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+
+	manifest1 := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value1
+`
+	manifest2 := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value2
+`
+
+	script := `#!/bin/sh
+CALL_COUNT="` + tmpDir + `/call_count"
+COUNT=$(cat "$CALL_COUNT" 2>/dev/null || echo "0")
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$CALL_COUNT"
+if [ "$COUNT" = "1" ]; then
+cat <<'MANIFEST1'
+` + manifest1 + `
+MANIFEST1
+else
+cat <<'MANIFEST2'
+` + manifest2 + `
+MANIFEST2
+fi
+`
+	err := os.WriteFile(fakeHelm, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2, "--detailed-exitcode"})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("Expected error with exit code 2 but got nil")
+	}
+
+	diffErr, ok := err.(Error)
+	if !ok {
+		t.Fatalf("Expected Error type but got %T: %v", err, err)
+	}
+	if diffErr.Code != 2 {
+		t.Errorf("Expected exit code 2 but got %d", diffErr.Code)
+	}
+}
+
+func TestLocalCmdDetailedExitCodeNoChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+	manifestYAML := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value
+`
+	err := os.WriteFile(fakeHelm, []byte(`#!/bin/sh
+cat <<'EOF'
+`+manifestYAML+`
+EOF
+`), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2, "--detailed-exitcode"})
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Errorf("Expected no error when no changes, but got: %v", err)
+	}
+}
+
+func TestLocalCmdNamespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+
+	script := `#!/bin/sh
+echo "$@" > ` + tmpDir + `/args
+cat <<'EOF'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+EOF
+`
+	err := os.WriteFile(fakeHelm, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2, "--namespace", "myns"})
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+
+	args1, _ := os.ReadFile(tmpDir + "/args")
+	if !strings.Contains(string(args1), "--namespace myns") {
+		t.Errorf("Expected --namespace myns in helm template args, got: %q", string(args1))
+	}
+}
+
+func TestLocalCmdHelmTemplateError(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeHelm := tmpDir + "/helm"
+
+	script := `#!/bin/sh
+echo "error: chart not found" >&2
+exit 1
+`
+	err := os.WriteFile(fakeHelm, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HELM_BIN", fakeHelm)
+
+	chart1 := t.TempDir()
+	chart2 := t.TempDir()
+
+	cmd := localCmd()
+	cmd.SetArgs([]string{chart1, chart2})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("Expected error when helm template fails but got nil")
 	}
 }

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"os"
 	"strings"
@@ -86,31 +85,20 @@ data:
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
 
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	os.Stdout = w
+	output, err := captureStdout(func() {
+		cmd := localCmd()
+		cmd.SetArgs([]string{chart1, chart2})
 
-	cmd := localCmd()
-	cmd.SetArgs([]string{chart1, chart2})
-
-	err = cmd.Execute()
-	w.Close()
-	os.Stdout = oldStdout
+		if execErr := cmd.Execute(); execErr != nil {
+			t.Errorf("Expected no error but got: %v", execErr)
+		}
+	})
 
 	if err != nil {
-		t.Fatalf("Expected no error but got: %v", err)
+		t.Fatalf("Failed to capture stdout: %v", err)
 	}
-
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("Failed to read from pipe: %v", err)
-	}
-	r.Close()
-	if buf.String() != "" {
-		t.Errorf("Expected no output when charts are identical, got: %q", buf.String())
+	if output != "" {
+		t.Errorf("Expected no output when charts are identical, got: %q", output)
 	}
 }
 
@@ -138,30 +126,18 @@ data:
 	chart1 := t.TempDir()
 	chart2 := t.TempDir()
 
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	os.Stdout = w
+	output, err := captureStdout(func() {
+		cmd := localCmd()
+		cmd.SetArgs([]string{chart1, chart2})
 
-	cmd := localCmd()
-	cmd.SetArgs([]string{chart1, chart2})
-
-	err = cmd.Execute()
-	w.Close()
-	os.Stdout = oldStdout
+		if execErr := cmd.Execute(); execErr != nil {
+			t.Errorf("Expected no error but got: %v", execErr)
+		}
+	})
 
 	if err != nil {
-		t.Fatalf("Expected no error but got: %v", err)
+		t.Fatalf("Failed to capture stdout: %v", err)
 	}
-
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("Failed to read from pipe: %v", err)
-	}
-	r.Close()
-	output := buf.String()
 
 	if !strings.Contains(output, "value1") || !strings.Contains(output, "value2") {
 		t.Errorf("Expected diff output containing value1 and value2, got: %q", output)
@@ -277,6 +253,92 @@ func TestLocalCmdHelmTemplateError(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("Expected error when helm template fails but got nil")
+	}
+}
+
+func TestPrepareStdinValues(t *testing.T) {
+	l := &local{
+		valueFiles: valueFiles{"-", "-", "real-values.yaml"},
+	}
+
+	stdinContent := `key: stdin-value
+`
+	tmpStdin, err := os.CreateTemp("", "fake-stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpStdin.Name())
+	if _, err := tmpStdin.WriteString(stdinContent); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpStdin.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldStdin := os.Stdin
+	f, err := os.Open(tmpStdin.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = f
+	defer func() {
+		os.Stdin = oldStdin
+		f.Close()
+	}()
+
+	cleanup, err := l.prepareStdinValues()
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("Expected cleanup function but got nil")
+	}
+
+	if l.valueFiles[0] == "-" {
+		t.Error("Expected first valueFile to be replaced with temp file path")
+	}
+	if l.valueFiles[1] == "-" {
+		t.Error("Expected second valueFile to be replaced with temp file path")
+	}
+	if l.valueFiles[0] != l.valueFiles[1] {
+		t.Errorf("Expected both '-' entries to point to the same temp file, got %q and %q", l.valueFiles[0], l.valueFiles[1])
+	}
+	if _, err := os.Stat(l.valueFiles[0]); os.IsNotExist(err) {
+		t.Errorf("Expected temp file %q to exist", l.valueFiles[0])
+	}
+	if l.valueFiles[2] != "real-values.yaml" {
+		t.Errorf("Expected third valueFile to be unchanged, got %q", l.valueFiles[2])
+	}
+
+	data, err := os.ReadFile(l.valueFiles[0])
+	if err != nil {
+		t.Fatalf("Failed to read temp file: %v", err)
+	}
+	if string(data) != stdinContent {
+		t.Errorf("Expected temp file to contain stdin content %q, got %q", stdinContent, string(data))
+	}
+
+	cleanup()
+
+	if _, err := os.Stat(l.valueFiles[0]); !os.IsNotExist(err) {
+		t.Errorf("Expected temp file %q to be removed after cleanup", l.valueFiles[0])
+	}
+}
+
+func TestPrepareStdinValuesNoStdin(t *testing.T) {
+	l := &local{
+		valueFiles: valueFiles{"values1.yaml", "values2.yaml"},
+	}
+
+	cleanup, err := l.prepareStdinValues()
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+	if cleanup != nil {
+		t.Error("Expected nil cleanup function when no stdin values")
+	}
+	if l.valueFiles[0] != "values1.yaml" || l.valueFiles[1] != "values2.yaml" {
+		t.Errorf("Expected valueFiles to be unchanged, got %v", l.valueFiles)
 	}
 }
 

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -87,13 +87,16 @@ data:
 	chart2 := t.TempDir()
 
 	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
 	os.Stdout = w
 
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	w.Close()
 	os.Stdout = oldStdout
 
@@ -102,7 +105,10 @@ data:
 	}
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("Failed to read from pipe: %v", err)
+	}
+	r.Close()
 	if buf.String() != "" {
 		t.Errorf("Expected no output when charts are identical, got: %q", buf.String())
 	}
@@ -133,13 +139,16 @@ data:
 	chart2 := t.TempDir()
 
 	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
 	os.Stdout = w
 
 	cmd := localCmd()
 	cmd.SetArgs([]string{chart1, chart2})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	w.Close()
 	os.Stdout = oldStdout
 
@@ -148,7 +157,10 @@ data:
 	}
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("Failed to read from pipe: %v", err)
+	}
+	r.Close()
 	output := buf.String()
 
 	if !strings.Contains(output, "value1") || !strings.Contains(output, "value2") {
@@ -244,7 +256,10 @@ data:
 		t.Fatalf("Expected no error but got: %v", err)
 	}
 
-	args1, _ := os.ReadFile(argsFile)
+	args1, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("Expected fake helm args file to be readable, but got: %v", err)
+	}
 	if !strings.Contains(string(args1), "--namespace myns") {
 		t.Errorf("Expected --namespace myns in helm template args, got: %q", string(args1))
 	}

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -258,8 +259,8 @@ fi
 		t.Fatal("Expected error with exit code 2 but got nil")
 	}
 
-	diffErr, ok := err.(Error)
-	if !ok {
+	var diffErr Error
+	if !errors.As(err, &diffErr) {
 		t.Fatalf("Expected Error type but got %T: %v", err, err)
 	}
 	if diffErr.Code != 2 {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -16,13 +16,23 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		case "dual":
 			countFile := os.Getenv("HELM_DIFF_FAKE_COUNT_FILE")
-			data, _ := os.ReadFile(countFile)
+			data, err := os.ReadFile(countFile)
+			if err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "failed to read count file %q: %v\n", countFile, err)
+				os.Exit(1)
+			}
 			count := 0
 			if len(data) > 0 {
-				fmt.Sscanf(string(data), "%d", &count)
+				if _, err := fmt.Sscanf(string(data), "%d", &count); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to parse count from %q: %v\n", string(data), err)
+					os.Exit(1)
+				}
 			}
 			count++
-			os.WriteFile(countFile, []byte(fmt.Sprintf("%d", count)), 0644)
+			if err := os.WriteFile(countFile, []byte(fmt.Sprintf("%d", count)), 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to write count file %q: %v\n", countFile, err)
+				os.Exit(1)
+			}
 			if count == 1 {
 				fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT_1"))
 			} else {
@@ -31,7 +41,10 @@ func TestMain(m *testing.M) {
 		case "capture_args":
 			argsFile := os.Getenv("HELM_DIFF_FAKE_ARGS_FILE")
 			if argsFile != "" {
-				os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], " ")), 0644)
+				if err := os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], " ")), 0644); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to write fake helm args file %q: %v\n", argsFile, err)
+					os.Exit(1)
+				}
 			}
 			fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT"))
 		default:

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -7,8 +7,18 @@ import (
 	"testing"
 )
 
+func shouldRunFakeHelm() bool {
+	if os.Getenv("HELM_DIFF_FAKE_HELM") != "1" {
+		return false
+	}
+	if len(os.Args) < 2 {
+		return false
+	}
+	return !strings.HasPrefix(os.Args[1], "-test.")
+}
+
 func TestMain(m *testing.M) {
-	if os.Getenv("HELM_DIFF_FAKE_HELM") == "1" {
+	if shouldRunFakeHelm() {
 		mode := os.Getenv("HELM_DIFF_FAKE_HELM_MODE")
 		switch mode {
 		case "error":

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("HELM_DIFF_FAKE_HELM") == "1" {
+		mode := os.Getenv("HELM_DIFF_FAKE_HELM_MODE")
+		switch mode {
+		case "error":
+			fmt.Fprintln(os.Stderr, "error: chart not found")
+			os.Exit(1)
+		case "dual":
+			countFile := os.Getenv("HELM_DIFF_FAKE_COUNT_FILE")
+			data, _ := os.ReadFile(countFile)
+			count := 0
+			if len(data) > 0 {
+				fmt.Sscanf(string(data), "%d", &count)
+			}
+			count++
+			os.WriteFile(countFile, []byte(fmt.Sprintf("%d", count)), 0644)
+			if count == 1 {
+				fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT_1"))
+			} else {
+				fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT_2"))
+			}
+		case "capture_args":
+			argsFile := os.Getenv("HELM_DIFF_FAKE_ARGS_FILE")
+			if argsFile != "" {
+				os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], " ")), 0644)
+			}
+			fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT"))
+		default:
+			fmt.Print(os.Getenv("HELM_DIFF_FAKE_OUTPUT"))
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func New() *cobra.Command {
 		revisionCmd(),
 		rollbackCmd(),
 		releaseCmd(),
+		localCmd(),
 	)
 	cmd.SetHelpCommand(&cobra.Command{}) // Disable the help command
 	return cmd


### PR DESCRIPTION
## Summary

- Add a new `local` subcommand that diffs two local chart directories by rendering both charts using `helm template` and showing the differences between the resulting manifests.
- Useful for comparing different versions of a chart, previewing changes before committing, and validating chart modifications.
- Based on #866 with additional fixes for linter compliance and test coverage.

## Usage

```
helm diff local ./chart-v1 ./chart-v2
helm diff local ./chart-v1 ./chart-v2 -f values.yaml
helm diff local /path/to/chart-a /path/to/chart-b --set replicas=3
```