### PR TITLE
Add public key to release assets for offline verification

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,14 @@ jobs:
           args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Export and upload public key
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          gpg --export --armor "${{ secrets.GPG_FINGERPRINT }}" > pubkey.asc
+          gh release upload ${{ github.ref_name }} pubkey.asc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   provenance-smoke-test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ helm plugin install https://github.com/databus23/helm-diff/releases/latest/downl
 For offline/airgapped environments, download the public key from the GitHub release assets on a connected machine, transfer it, and import it locally:
 
 ```shell
-gpg --import <public-key.asc>
+curl -sL https://github.com/databus23/helm-diff/releases/latest/download/pubkey.asc -o pubkey.asc
+gpg --import pubkey.asc
 ```
 
 The public key fingerprint is published in the notes for each GitHub release.


### PR DESCRIPTION
- Export GPG public key as `pubkey.asc` and upload to release assets during release workflow
- Update README offline instructions to download `pubkey.asc` from release assets
- Fix Helm 4 provenance verification: use direct tarball URL instead of git repo URL