### PR TITLE
fix: bundle install scripts in release archives (#504)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
+        name: Verify archives bundle plugin files (snapshot only)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          set -e
+          missing=0
+          for f in dist/helm-diff-*.tgz; do
+            echo "== $f =="
+            tar tzf "$f"
+            for member in diff/plugin.yaml diff/install-binary.sh diff/install-binary.ps1 diff/bin/diff; do
+              if ! tar tzf "$f" | grep -q "^${member}$"; then
+                echo "ERROR: ${member} missing from ${f}"
+                missing=1
+              fi
+            done
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Smoke test failed: required plugin files missing from one or more archives"
+            exit 1
+          fi
+          echo "Smoke test passed: all archives bundle plugin.yaml, install scripts, and binary"
+      -
         name: Export and upload public key
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,34 @@ jobs:
           fi
           echo "Smoke test passed: all archives bundle plugin.yaml, install scripts, and binary"
       -
+        name: Set up Helm
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.18.6
+      -
+        name: End-to-end archive install test (snapshot only)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          set -e
+          # Reproduce issue #504: extract a release archive and install from it.
+          mkdir -p /tmp/archive-test
+          tar xzf dist/helm-diff-linux-amd64.tgz -C /tmp/archive-test
+          echo "Extracted archive layout:"
+          find /tmp/archive-test/diff -maxdepth 2 -type f | sort
+
+          out="$(helm plugin install /tmp/archive-test/diff 2>&1)"
+          echo "$out"
+          # The install hook must find the bundled binary already staged in
+          # HELM_PLUGIN_DIR and skip the network download.
+          echo "$out" | grep -q "skipping download" || {
+            echo "ERROR: install hook did not skip the download."
+            echo "Archive install must not hit the network (binary is already bundled)."
+            exit 1
+          }
+          helm diff version
+          echo "End-to-end archive install test passed: installed from archive without downloading"
+      -
         name: Export and upload public key
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,12 +75,17 @@ jobs:
           for f in dist/helm-diff-*.tgz; do
             echo "== $f =="
             tar tzf "$f"
-            for member in diff/plugin.yaml diff/install-binary.sh diff/install-binary.ps1 diff/bin/diff; do
+            for member in diff/plugin.yaml diff/install-binary.sh diff/install-binary.ps1; do
               if ! tar tzf "$f" | grep -q "^${member}$"; then
                 echo "ERROR: ${member} missing from ${f}"
                 missing=1
               fi
             done
+            # the binary has a .exe suffix on windows archives
+            if ! tar tzf "$f" | grep -qE '^diff/bin/diff(\.exe)?$'; then
+              echo "ERROR: diff/bin/diff missing from ${f}"
+              missing=1
+            fi
           done
           if [ "$missing" -ne 0 ]; then
             echo "Smoke test failed: required plugin files missing from one or more archives"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,8 @@ archives:
     - README.md
     - plugin.yaml
     - LICENSE
+    - install-binary.sh
+    - install-binary.ps1
 
 signs:
   - id: plugin-provenance

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ helm plugin install https://github.com/databus23/helm-diff
 
 If installing this in an offline/airgapped environment, download the platform-specific binary archive (e.g., `helm-diff-linux-amd64.tgz` or `helm-diff-windows-amd64.tgz`) from [releases](https://github.com/databus23/helm-diff/releases). Make sure to select the correct `.tgz` file for your operating system and architecture.
 
+The release archives include everything needed to install the plugin (binary, `plugin.yaml`, and the install scripts). The simplest way to install offline is to extract the archive and point `helm plugin install` at the extracted directory:
+
+```
+tar xzf helm-diff-linux-amd64.tgz   # extracts into a ./diff directory
+helm plugin install ./diff
+```
+
+The install script detects that the binary is already bundled and skips the GitHub download.
+
+Alternatively, if you keep a separate local checkout of the plugin source, you can point the installer at a downloaded `.tgz` via the `HELM_DIFF_BIN_TGZ` environment variable.
+
 Set `HELM_DIFF_BIN_TGZ` to the absolute path to the downloaded binary archive:
 
 **POSIX shell:**

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -40,7 +40,22 @@ function Get-Url {
 
 function Download-Plugin {
   param ([Parameter(Mandatory=$true)][string] $Url, [Parameter(Mandatory=$true)][string] $Output)
-  Invoke-WebRequest -OutFile $Output $Url
+  # Retry with backoff to absorb transient failures, e.g. a release window
+  # where the "latest" asset is already published but not fully uploaded yet.
+  $maxAttempts = 5
+  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    try {
+      Invoke-WebRequest -OutFile $Output $Url
+      return
+    } catch {
+      if ($attempt -eq $maxAttempts) {
+        throw "Failed to download $Url after $maxAttempts attempts: $_"
+      }
+      $backoff = $attempt * 3
+      Write-Host "Download failed (attempt $attempt/$maxAttempts), retrying in ${backoff}s..."
+      Start-Sleep -Seconds $backoff
+    }
+  }
 }
 
 function Install-Plugin {

--- a/install-binary.ps1
+++ b/install-binary.ps1
@@ -56,6 +56,17 @@ $ErrorActionPreference = "Stop"
 
 $archiveName = "helm-diff.tgz"
 $arch = Get-Architecture
+
+# If installing (not updating) and the binary is already staged in the
+# plugin dir (e.g. installing from a release archive that bundles the
+# correct platform binary), skip the redundant download. Update mode
+# always re-downloads.
+$pluginBin = Join-Path $env:HELM_PLUGIN_DIR "bin" "diff.exe"
+if (-not $Update -and (Test-Path $pluginBin -PathType Leaf)) {
+    Write-Host "Binary already present at $pluginBin, skipping download"
+    exit 0
+}
+
 $tmpDir = New-TemporaryDirectory
 trap {   Remove-Item -path $tmpDir -Recurse -Force }
 $output = Join-Path $tmpDir $archiveName

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -123,10 +123,33 @@ downloadFile() {
   fi
 
   echo "Downloading $DOWNLOAD_URL"
-  if command -v curl >/dev/null 2>&1; then
-    curl -sSf -L "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q -O - "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"
+  # Retry with backoff to absorb transient failures, e.g. a release window
+  # where the "latest" asset is already published but not fully uploaded yet.
+  dl_attempts=5
+  dl_attempt=1
+  dl_ok=0
+  while [ "$dl_attempt" -le "$dl_attempts" ]; do
+    if command -v curl >/dev/null 2>&1; then
+      if curl -sSfL "$DOWNLOAD_URL" >"$PLUGIN_TMP_FILE"; then
+        dl_ok=1
+        break
+      fi
+    elif command -v wget >/dev/null 2>&1; then
+      if wget -q -O "$PLUGIN_TMP_FILE" "$DOWNLOAD_URL"; then
+        dl_ok=1
+        break
+      fi
+    else
+      echo "Either curl or wget is required"
+      exit 1
+    fi
+    echo "Download failed (attempt $dl_attempt/$dl_attempts), retrying in $((dl_attempt * 3))s..."
+    sleep "$((dl_attempt * 3))"
+    dl_attempt=$((dl_attempt + 1))
+  done
+  if [ "$dl_ok" -ne 1 ]; then
+    echo "Error: failed to download $DOWNLOAD_URL after $dl_attempts attempts"
+    exit 1
   fi
 }
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -154,6 +154,17 @@ exit_trap() {
   exit $result
 }
 
+# alreadyInstalled returns 0 when the platform binary is already staged in
+# the plugin dir. This is the case when installing from a release archive
+# (which bundles the correct platform binary), so the redundant download
+# can be skipped. Update mode always re-downloads.
+alreadyInstalled() {
+  [ "$SCRIPT_MODE" = "install" ] || return 1
+  bin="$HELM_PLUGIN_DIR/bin/diff"
+  [ "$OS" = "windows" ] && bin="$bin.exe"
+  [ -x "$bin" ]
+}
+
 # --- Execution ---
 # Stop execution on any error
 trap "exit_trap" EXIT
@@ -162,6 +173,13 @@ set -e
 initArch
 initOS
 verifySupported
+
+if alreadyInstalled; then
+  echo "Binary already present at $HELM_PLUGIN_DIR/bin/diff, skipping download"
+  trap - EXIT
+  exit 0
+fi
+
 getDownloadURL
 mkTempDir
 downloadFile


### PR DESCRIPTION
## Problem

Extracting a release `.tgz` (e.g. `helm-diff-linux-amd64.tgz`) and running `helm plugin install ./diff` fails:

```
sh: 1: .../diff/install-binary.sh: not found
Error: plugin install hook for "diff" exited with error
```

The goreleaser-built archives only shipped `plugin.yaml`, the binary, `README.md` and `LICENSE`, but `plugin.yaml` defines install/update hooks referencing `install-binary.sh` / `install-binary.ps1`, which were not bundled.

Fixes https://github.com/databus23/helm-diff/issues/504

## Changes

- **`.goreleaser.yml`** — bundle `install-binary.sh` and `install-binary.ps1` in every archive.
- **`install-binary.sh` / `install-binary.ps1`** — skip the redundant binary download when the platform binary is already staged in `HELM_PLUGIN_DIR` during **install** (the archive already bundles the correct binary). **Update** mode (`-u`) always re-downloads.
- **`.github/workflows/release.yaml`** — snapshot-only smoke test that fails if any archive is missing `plugin.yaml`, the install scripts, or the binary.
- **`README.md`** — document that `helm plugin install ./diff` now works directly from an extracted release `.tgz`.

## How install flows behave

| Flow | Before | After |
|---|---|---|
| `helm plugin install https://github.com/databus23/helm-diff` (git clone) | works (downloads binary) | unchanged |
| `helm plugin install ./diff` from extracted release `.tgz` | **fails** (script missing) | works, skips download (offline) |
| `helm plugin update` (`-u`) | works (re-downloads) | unchanged |

## Verification

- `shellcheck install-binary.sh` — clean
- Local simulation harness (3 scenarios): archive-install skip, git-clone download path, and `-u` no-skip — all pass
- CI adds a snapshot smoke test asserting archive contents

## Notes

- Supersedes #812, which targeted the legacy/unused Makefile `dist` target rather than the goreleaser pipeline that actually produces releases.
- The `HELM_DIFF_BIN_TGZ` airgap flow from #964 keeps working unchanged.