### PR TITLE
ci: bump Helm support matrix to v3.21.0 and v4.2.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Always reference these instructions first and fallback to search or bash command
 
 **Prerequisites:**
 - Go >= 1.21 (currently uses Go 1.24.5)
-- Helm v3 (tested with v3.17.4 and v3.18.6)
+- Helm v3/v4 (tested with v3.21.0 and v4.2.0)
 
 **Build Process:**
 - Build the plugin: `make build` - includes linting and compiles the binary.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,21 +40,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [default]
         experimental: [false]
-        helm-version: [v3.18.6, v3.21.0, v4.2.0]
+        helm-version: [v3.21.0, v4.2.0]
         include:
-          - os: windows-latest
-            shell: wsl
-            experimental: false
-            helm-version: v3.18.6
-          - os: windows-latest
-            shell: cygwin
-            experimental: false
-            helm-version: v3.18.6
-          - os: ubuntu-latest
-            container: alpine
-            shell: sh
-            experimental: false
-            helm-version: v3.18.6
           - os: windows-latest
             shell: wsl
             experimental: false
@@ -115,10 +102,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # Helm maintains the latest minor version only and therefore each Helmfile version supports 2 Helm minor versions.
-          # That's why we cover only 2 Helm minor versions in this matrix.
+          # Cover the latest minor of each supported Helm major (v3 and v4).
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
-          - helm-version: v3.18.6
           - helm-version: v3.21.0
           - helm-version: v4.2.0
     steps:


### PR DESCRIPTION
Bumps the CI Helm support matrix from `v3.18.6, v3.21.0, v4.2.0` to `v3.21.0, v4.2.0` so CI covers the latest minor of each supported Helm major.

## Changes
- **`.github/workflows/ci.yaml`**
  - `helm-install` matrix: drop `v3.18.6` from the version list and remove its 3 `include` entries (windows wsl/cygwin + alpine), keeping the equivalents for `v3.21.0` and `v4.2.0`.
  - `integration-tests` matrix: drop `v3.18.6`; update the now-stale comment (was about "2 Helm minor versions", now covers the latest of each major).
- **`.github/copilot-instructions.md`** — update the tested-with note to `v3.21.0` and `v4.2.0`.

## Net effect
Fewer matrix jobs (dropped v3.18.6 across all os/shell combos) while still testing the latest helm 3 and helm 4.