### PR TITLE
chore: bump version to 3.15.9

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.15.8"
+version: "3.15.9"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Bumps plugin version from 3.15.8 to 3.15.9.