### PR TITLE
chore: bump Go to 1.26.4 to fix CVE-2026-42504

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 # See https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
 # for the latest gh install instructions when the below didn't work

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databus23/helm-diff/v3
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Fixes #1022.

Upgrades Go from 1.26.3 to 1.26.4 to address HIGH severity CVE-2026-42504.

- go.mod: `go 1.26.3` -> `go 1.26.4` (also drives CI/lint/release workflows via `go-version-file: go.mod`)
- Dockerfile.release: `golang:1.26.3` -> `golang:1.26.4`