### PR TITLE
Support array of scalars in structured output

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -602,6 +602,15 @@ spec:
       containers:
       - name: app
         image: demo:v1
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-type
+                operator: In
+                values:
+                - standard
 `
 	newManifest := `
 apiVersion: apps/v1
@@ -616,6 +625,15 @@ spec:
       containers:
       - name: app
         image: demo:v2
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-type
+                operator: In
+                values:
+                - dedicated
 `
 	oldIndex := manifest.Parse([]byte(oldManifest), "prod", true)
 	newIndex := manifest.Parse([]byte(newManifest), "prod", true)

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -651,7 +651,7 @@ spec:
 	require.Equal(t, "Deployment", entry.Kind)
 	require.Equal(t, "prod", entry.Namespace)
 	require.Equal(t, "web", entry.Name)
-	require.Len(t, entry.Changes, 2)
+	require.Len(t, entry.Changes, 3)
 	replicasChange, ok := findChange(entry.Changes, "spec", "replicas")
 	require.True(t, ok)
 	require.InDelta(t, float64(2), replicasChange.OldValue, 0.001)
@@ -661,6 +661,11 @@ spec:
 	require.True(t, ok)
 	require.Equal(t, "demo:v1", imageChange.OldValue)
 	require.Equal(t, "demo:v2", imageChange.NewValue)
+
+	affinityChange, ok := findChange(entry.Changes, "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values", "0")
+	require.True(t, ok)
+	require.Equal(t, "standard", affinityChange.OldValue)
+	require.Equal(t, "dedicated", affinityChange.NewValue)
 }
 
 func TestStructuredOutputAddAndRemove(t *testing.T) {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -613,8 +613,12 @@ spec:
                 - standard
       priorities:
       - 1
-      enabled:
+      booleanArrayField:
       - true
+      multiTypeField:
+      - 3
+      - true
+      - "string"
 `
 	newManifest := `
 apiVersion: apps/v1
@@ -640,8 +644,12 @@ spec:
                 - dedicated
       priorities:
       - 2
-      enabled:
+      booleanArrayField:
       - false
+      multiTypeField:
+      - false
+      - "new-string"
+      - 2
 `
 	oldIndex := manifest.Parse([]byte(oldManifest), "prod", true)
 	newIndex := manifest.Parse([]byte(newManifest), "prod", true)
@@ -659,7 +667,7 @@ spec:
 	require.Equal(t, "Deployment", entry.Kind)
 	require.Equal(t, "prod", entry.Namespace)
 	require.Equal(t, "web", entry.Name)
-	require.Len(t, entry.Changes, 5)
+	require.Len(t, entry.Changes, 8)
 	replicasChange, ok := findChange(entry.Changes, "spec", "replicas")
 	require.True(t, ok)
 	require.InDelta(t, float64(2), replicasChange.OldValue, 0.001)
@@ -680,10 +688,25 @@ spec:
 	require.InDelta(t, float64(1), priorityChange.OldValue, 0.001)
 	require.InDelta(t, float64(2), priorityChange.NewValue, 0.001)
 
-	enabledChange, ok := findChange(entry.Changes, "spec.template.spec.enabled", "0")
+	booleanArrayFieldChange, ok := findChange(entry.Changes, "spec.template.spec.booleanArrayField", "0")
 	require.True(t, ok)
-	require.Equal(t, true, enabledChange.OldValue)
-	require.Equal(t, false, enabledChange.NewValue)
+	require.Equal(t, true, booleanArrayFieldChange.OldValue)
+	require.Equal(t, false, booleanArrayFieldChange.NewValue)
+
+	multiTypeFieldChange0, ok := findChange(entry.Changes, "spec.template.spec.multiTypeField", "0")
+	require.True(t, ok)
+	require.InDelta(t, float64(3), multiTypeFieldChange0.OldValue, 0.001)
+	require.Equal(t, false, multiTypeFieldChange0.NewValue)
+
+	multiTypeFieldChange1, ok := findChange(entry.Changes, "spec.template.spec.multiTypeField", "1")
+	require.True(t, ok)
+	require.Equal(t, true, multiTypeFieldChange1.OldValue)
+	require.Equal(t, "new-string", multiTypeFieldChange1.NewValue)
+
+	multiTypeFieldChange2, ok := findChange(entry.Changes, "spec.template.spec.multiTypeField", "2")
+	require.True(t, ok)
+	require.Equal(t, "string", multiTypeFieldChange2.OldValue)
+	require.InDelta(t, float64(2), multiTypeFieldChange2.NewValue, 0.001)
 }
 
 func TestStructuredOutputAddAndRemove(t *testing.T) {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -611,6 +611,10 @@ spec:
                 operator: In
                 values:
                 - standard
+      priorities:
+      - 1
+      enabled:
+      - true
 `
 	newManifest := `
 apiVersion: apps/v1
@@ -634,6 +638,10 @@ spec:
                 operator: In
                 values:
                 - dedicated
+      priorities:
+      - 2
+      enabled:
+      - false
 `
 	oldIndex := manifest.Parse([]byte(oldManifest), "prod", true)
 	newIndex := manifest.Parse([]byte(newManifest), "prod", true)
@@ -651,7 +659,7 @@ spec:
 	require.Equal(t, "Deployment", entry.Kind)
 	require.Equal(t, "prod", entry.Namespace)
 	require.Equal(t, "web", entry.Name)
-	require.Len(t, entry.Changes, 3)
+	require.Len(t, entry.Changes, 5)
 	replicasChange, ok := findChange(entry.Changes, "spec", "replicas")
 	require.True(t, ok)
 	require.InDelta(t, float64(2), replicasChange.OldValue, 0.001)
@@ -666,6 +674,16 @@ spec:
 	require.True(t, ok)
 	require.Equal(t, "standard", affinityChange.OldValue)
 	require.Equal(t, "dedicated", affinityChange.NewValue)
+
+	priorityChange, ok := findChange(entry.Changes, "spec.template.spec.priorities", "0")
+	require.True(t, ok)
+	require.InDelta(t, float64(1), priorityChange.OldValue, 0.001)
+	require.InDelta(t, float64(2), priorityChange.NewValue, 0.001)
+
+	enabledChange, ok := findChange(entry.Changes, "spec.template.spec.enabled", "0")
+	require.True(t, ok)
+	require.Equal(t, true, enabledChange.OldValue)
+	require.Equal(t, false, enabledChange.NewValue)
 }
 
 func TestStructuredOutputAddAndRemove(t *testing.T) {
@@ -677,7 +695,20 @@ kind: Job
 metadata:
   name: migrate
   namespace: ops
-spec: {}
+spec:
+  restartPolicy: "Never"
+  containers:
+  - name: app
+    image: demo:v1
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: node-type
+              operator: In
+              values:
+              - standard
 `
 	newIndex := manifest.Parse([]byte(newManifest), "ops", true)
 
@@ -688,6 +719,7 @@ spec: {}
 	var entries []StructuredEntry
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &entries))
 	require.Len(t, entries, 1)
+
 	require.Equal(t, "ADD", entries[0].ChangeType)
 	require.True(t, entries[0].ResourceStatus.NewExists)
 	require.False(t, entries[0].ResourceStatus.OldExists)

--- a/diff/structured.go
+++ b/diff/structured.go
@@ -271,6 +271,20 @@ func diffArrayNodes(changes *[]FieldChange, tokens []string, oldNode, newNode in
 			if reflect.DeepEqual(oldVal, newVal) {
 				continue
 			}
+			// If both oldVal and newVal are strings, we can directly record the change without further recursion.
+			if oldStr, ok := oldVal.(string); ok {
+				if newStr, ok := newVal.(string); ok {
+					path, field := splitTokens(next)
+					*changes = append(*changes, FieldChange{
+						Path:     path,
+						Field:    field,
+						Change:   "replace",
+						OldValue: oldStr,
+						NewValue: newStr,
+					})
+					continue
+				}
+			}
 			subPatch, err := createNodePatch(oldVal, newVal)
 			if err != nil {
 				return err

--- a/diff/structured.go
+++ b/diff/structured.go
@@ -271,19 +271,17 @@ func diffArrayNodes(changes *[]FieldChange, tokens []string, oldNode, newNode in
 			if reflect.DeepEqual(oldVal, newVal) {
 				continue
 			}
-			// If both oldVal and newVal are strings, we can directly record the change without further recursion.
-			if oldStr, ok := oldVal.(string); ok {
-				if newStr, ok := newVal.(string); ok {
-					path, field := splitTokens(next)
-					*changes = append(*changes, FieldChange{
-						Path:     path,
-						Field:    field,
-						Change:   "replace",
-						OldValue: oldStr,
-						NewValue: newStr,
-					})
-					continue
-				}
+			// createNodePatch only supports JSON objects; handle scalar values directly
+			if isScalarValue(oldVal) && isScalarValue(newVal) {
+				path, field := splitTokens(next)
+				*changes = append(*changes, FieldChange{
+					Path:     path,
+					Field:    field,
+					Change:   "replace",
+					OldValue: oldVal,
+					NewValue: newVal,
+				})
+				continue
 			}
 			subPatch, err := createNodePatch(oldVal, newVal)
 			if err != nil {
@@ -323,6 +321,18 @@ func diffArrayNodes(changes *[]FieldChange, tokens []string, oldNode, newNode in
 	}
 
 	return nil
+}
+
+func isScalarValue(value interface{}) bool {
+	switch value.(type) {
+	case string, bool,
+		float32, float64,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return true
+	default:
+		return false
+	}
 }
 
 func createNodePatch(oldNode, newNode interface{}) (interface{}, error) {


### PR DESCRIPTION
## Summary

We've run into an issue when using `--output structured` in that changes to lists of strings (eg. those in `nodeSelectorTerms.matchExpressions.values`) does not get rendered properly.

## Current behaviour

Running the below command results in failure.

> helm diff upgrade -n apps <release> <chart> --output structured --values ...

Warning raised:

> Warning: failed to build structured entry for apps, k8s-cron, CronJob (batch) (kind: CronJob, changeType: MODIFY): Invalid JSON Document

Resulting output for that resource:

```json
[
  {
    "name": "apps, k8s-cron, CronJob (batch)",
    "changeType": "MODIFY",
    "resourceStatus": {
      "oldExists": false,
      "newExists": false
    }
  },
  ...
]
```

## Suspected cause

It appears that whilst generating a structured diff, maps and arrays of maps are handled correctly, but arrays of strings are not; they seem to be passed to [createNodePatch ](https://github.com/databus23/helm-diff/blob/46564405f798ba6a011b37fedf22dcfefc30ce28/diff/structured.go#L314) regardless, which tries to marshal and unmarshal these strings (which causes an error during the unmarshal).

## Proposed fix

Inside [diffArrayNodes](https://github.com/databus23/helm-diff/blob/46564405f798ba6a011b37fedf22dcfefc30ce28/diff/structured.go#L249), we can check if the two values are strings, then append a change immediately without a need for any further processing.

## Notes

This PR's first commit will just be adding to the relevant test case, which should show the behaviour mentioned above (once the workflow runs). The proposed fix will be pushed in a subsequent commit