### PR TITLE
install-binary.sh: Use $HELM_BIN in HELM_HOME assignment

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -16,7 +16,7 @@ if command -v cygpath >/dev/null 2>&1; then
 fi
 
 [ -z "$HELM_BIN" ] && HELM_BIN=$(command -v helm)
-[ -z "$HELM_HOME" ] && HELM_HOME=$(helm env | grep 'HELM_DATA_HOME' | cut -d '=' -f2 | tr -d '"')
+[ -z "$HELM_HOME" ] && HELM_HOME=$($HELM_BIN env | grep 'HELM_DATA_HOME' | cut -d '=' -f2 | tr -d '"')
 mkdir -p "$HELM_HOME"
 : "${HELM_PLUGIN_DIR:="$HELM_HOME/plugins/helm-diff"}"
 


### PR DESCRIPTION
When a command named 'helm' does not actually exist (for example when
Helm is invoked as 'helm4' or similar), an error like the following may
be printed even if installation then continues to apparently succeed.

   [/path/to]/helm/plugins/4/helm-diff/install-binary.sh: 19: helm: not found
   mkdir: cannot create directory '': No such file or directory
