### PR TITLE
build(deps): bump Helm to v3.21.3 and v4.2.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         shell: [default]
         experimental: [false]
-        helm-version: [v3.18.6, v3.21.1, v4.2.1]
+        helm-version: [v3.18.6, v3.21.3, v4.2.3]
         include:
           - os: windows-latest
             shell: wsl
@@ -58,29 +58,29 @@ jobs:
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v3.21.1
+            helm-version: v3.21.3
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v3.21.1
+            helm-version: v3.21.3
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v3.21.1
+            helm-version: v3.21.3
           - os: windows-latest
             shell: wsl
             experimental: false
-            helm-version: v4.2.1
+            helm-version: v4.2.3
           - os: windows-latest
             shell: cygwin
             experimental: false
-            helm-version: v4.2.1
+            helm-version: v4.2.3
           - os: ubuntu-latest
             container: alpine
             shell: sh
             experimental: false
-            helm-version: v4.2.1
+            helm-version: v4.2.3
 
     steps:
       - name: Disable autocrlf
@@ -119,8 +119,8 @@ jobs:
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.18.6
-          - helm-version: v3.21.1
-          - helm-version: v4.2.1
+          - helm-version: v3.21.3
+          - helm-version: v4.2.3
     steps:
       - uses: helm/kind-action@v1.14.0
         with:


### PR DESCRIPTION
Bumps the CI matrix Helm versions:

- v3.21.1 → v3.21.3
- v4.2.1 → v4.2.3

Follow-up to #1029 (go.mod dependency bump). Updates the GitHub Actions CI matrix to test against the latest Helm patch releases.