### PR TITLE
feat: omit 'app.kubernetes.io/managed-by' label on three-way-diff

### DIFF
--- a/manifest/util.go
+++ b/manifest/util.go
@@ -35,7 +35,7 @@ func deleteStatusAndTidyMetadata(obj []byte) (map[string]interface{}, error) {
 			delete(metadata, "annotations")
 		}
 	}
-	
+
 	if a := metadata["labels"]; a != nil {
 		labels := a.(map[string]interface{})
 		delete(labels, "app.kubernetes.io/managed-by")

--- a/manifest/util.go
+++ b/manifest/util.go
@@ -40,8 +40,8 @@ func deleteStatusAndTidyMetadata(obj []byte) (map[string]interface{}, error) {
 		labels := a.(map[string]interface{})
 		delete(labels, "app.kubernetes.io/managed-by")
 
-		if len(annotations) == 0 {
-			delete(labels, "annotations")
+		if len(labels) == 0 {
+			delete(metadata, "labels")
 		}
 	}
 

--- a/manifest/util.go
+++ b/manifest/util.go
@@ -25,25 +25,30 @@ func deleteStatusAndTidyMetadata(obj []byte) (map[string]interface{}, error) {
 
 	// See the below for the goal of this metadata tidy logic.
 	// https://github.com/databus23/helm-diff/issues/326#issuecomment-1008253274
-	if a := metadata["annotations"]; a != nil {
-		annotations := a.(map[string]interface{})
-		delete(annotations, "meta.helm.sh/release-name")
-		delete(annotations, "meta.helm.sh/release-namespace")
-		delete(annotations, "deployment.kubernetes.io/revision")
-
-		if len(annotations) == 0 {
-			delete(metadata, "annotations")
-		}
-	}
-
-	if a := metadata["labels"]; a != nil {
-		labels := a.(map[string]interface{})
-		delete(labels, "app.kubernetes.io/managed-by")
-
-		if len(labels) == 0 {
-			delete(metadata, "labels")
-		}
-	}
+	pruneNestedMap(metadata, "annotations",
+		"meta.helm.sh/release-name",
+		"meta.helm.sh/release-namespace",
+		"deployment.kubernetes.io/revision",
+	)
+	pruneNestedMap(metadata, "labels", "app.kubernetes.io/managed-by")
 
 	return objectMap, nil
+}
+
+// pruneNestedMap removes the given fields from the nested map found at key in
+// target. If the nested map ends up empty afterwards, key itself is removed
+// from target.
+func pruneNestedMap(target map[string]interface{}, key string, fields ...string) {
+	sub, ok := target[key].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	for _, field := range fields {
+		delete(sub, field)
+	}
+
+	if len(sub) == 0 {
+		delete(target, key)
+	}
 }

--- a/manifest/util.go
+++ b/manifest/util.go
@@ -35,6 +35,15 @@ func deleteStatusAndTidyMetadata(obj []byte) (map[string]interface{}, error) {
 			delete(metadata, "annotations")
 		}
 	}
+	
+	if a := metadata["labels"]; a != nil {
+		labels := a.(map[string]interface{})
+		delete(labels, "app.kubernetes.io/managed-by")
+
+		if len(annotations) == 0 {
+			delete(labels, "annotations")
+		}
+	}
 
 	return objectMap, nil
 }

--- a/manifest/util_test.go
+++ b/manifest/util_test.go
@@ -28,12 +28,16 @@ func Test_deleteStatusAndTidyMetadata(t *testing.T) {
     "metadata": {
         "annotations": {
             "deployment.kubernetes.io/revision": "1",
-			"meta.helm.sh/release-name": "test-release",
-			"meta.helm.sh/release-namespace": "test-ns",
-			"other-annot": "value"
+            "meta.helm.sh/release-name": "test-release",
+            "meta.helm.sh/release-namespace": "test-ns",
+            "other-annot": "value"
         },
         "creationTimestamp": "2025-03-03T10:07:50Z",
         "generation": 1,
+        "labels": {
+            "app": "nginx",
+            "app.kubernetes.io/managed-by": "Helm"
+        },
         "name": "nginx-deployment",
         "namespace": "test-ns",
         "resourceVersion": "33648",
@@ -64,6 +68,9 @@ func Test_deleteStatusAndTidyMetadata(t *testing.T) {
 					"annotations": map[string]interface{}{
 						"other-annot": "value",
 					},
+					"labels": map[string]interface{}{
+						"app": "nginx",
+					},
 					"name":      "nginx-deployment",
 					"namespace": "test-ns",
 				},
@@ -79,6 +86,27 @@ func Test_deleteStatusAndTidyMetadata(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty labels are removed",
+			obj: []byte(`
+{
+    "kind": "ConfigMap",
+    "metadata": {
+        "labels": {
+            "app.kubernetes.io/managed-by": "Helm"
+        },
+        "name": "example"
+    }
+}
+`),
+			want: map[string]interface{}{
+				"kind": "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "example",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
Ref: https://github.com/databus23/helm-diff/issues/326#issuecomment-1008222454

> Worth noting, the app.kubernetes.io/managed-by: Helm label is [handled the same way](https://github.com/helm/helm/blob/v3.7.2/pkg/action/validate.go?rgh-link-date=2022-01-09T03%3A34%3A29.000Z#L112-L148), but because it predates the auto-added metadata, it's present in most people's Helm templates, which is why you're not seeing it in this test-case.

I'm using helm diff with three-way-diff in a upgrade --dry-mode and I observe changes on each resource which would remove `app.kubernetes.io/managed-by`.