### PR TITLE
Add external diff tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ When a kind is suppressed via `--suppress`, `changesSuppressed` is set to `true`
 
 ### External diff tool
 
-Set `--diff-tool` to a command and helm-diff renders the diff with that command instead of its built-in renderers. It writes the old and the new manifests into two temporary files and appends their paths as the last two arguments:
+Set `--diff-tool` to a command and helm-diff renders the diff with that command instead of its built-in renderers. It writes the old and the new manifests into two temporary files (named `old.yaml` and `new.yaml` in a private temporary directory) and appends their paths as the last two arguments:
 
 ```shell
 # any tool that accepts two file paths works
@@ -240,12 +240,15 @@ export HELM_DIFF_TOOL="difft --language yaml"
 helm diff upgrade api ./charts/api
 ```
 
-`--diff-tool` takes precedence over `HELM_DIFF_TOOL`, and either one overrides `--output`. There is no default command: without one, the built-in `--output` renderer is used.
+`--diff-tool` takes precedence over `HELM_DIFF_TOOL`, and either one overrides `--output`. An explicit `--output` (or an explicitly empty `--diff-tool ""`) also wins over `HELM_DIFF_TOOL`, so scripts that parse a specific output format cannot be silently broken by a variable inherited from a shell profile: the environment variable only applies when neither flag is given. There is no default command: without one, the built-in `--output` renderer is used.
 
 Notes:
 
-- The command is executed directly, not through a shell, so pipes and shell expansion are not available. Wrap arguments containing spaces in quotes, for example `--diff-tool '"/opt/my tools/diff" -u'`. For anything more involved, point the flag at a wrapper script.
-- The manifests handed to the tool are the ones from the diff report, so `--suppress`, `--suppress-output-line-regex` and secret redaction still apply. Secrets are redacted unless `--show-secrets` is given, and suppressed kinds are replaced by a placeholder on both sides.
+- The command is executed directly, not through a shell, so pipes and shell expansion are not available. Wrap arguments containing spaces in quotes, for example `--diff-tool '"/opt/my tools/diff" -u'`; an unclosed quote is rejected with an error. For anything more involved, point the flag at a wrapper script.
+- Each resource in the temporary files is preceded by a `# Resource:`/`# Change:` header comment (change types: `ADD`, `REMOVE`, `MODIFY`, `OWNERSHIP`), because an external tool would otherwise have no way to show them.
+- The manifests handed to the tool are the ones from the diff report, so `--suppress`, `--suppress-output-line-regex` and secret redaction still apply. Secrets are redacted unless `--show-secrets` is given; suppressed kinds — and entries whose diff is empty after `--suppress-output-line-regex` — are replaced by a placeholder on both sides.
+- The command must block until it has finished reading the two files. GUI tools that return immediately (for example `code --diff`) may find the temporary directory already deleted before they display it; make them wait (for example `code --wait --diff`) or wrap them in a script that waits.
+- There is no timeout around the command: a tool that never exits keeps helm-diff running.
 - An exit code of `1` from the tool is treated as "differences found" and ignored. Other failures are reported on stderr without aborting helm-diff.
 - helm-diff's own exit code is unaffected by the tool: `--detailed-exitcode` still returns `2` based on the changes helm-diff detected.
 - `--context`/`-C` is not applied; use the equivalent option of the external tool (for example `diff -U3`).

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ export HELM_DIFF_TOOL="difft --language yaml"
 helm diff upgrade api ./charts/api
 ```
 
-`--diff-tool` takes precedence over `HELM_DIFF_TOOL`, and either one overrides `--output`. An explicit `--output` (or an explicitly empty `--diff-tool ""`) also wins over `HELM_DIFF_TOOL`, so scripts that parse a specific output format cannot be silently broken by a variable inherited from a shell profile: the environment variable only applies when neither flag is given. There is no default command: without one, the built-in `--output` renderer is used.
+`--diff-tool` overrides both `--output` and `HELM_DIFF_TOOL`. `HELM_DIFF_TOOL` applies only when neither `--output` nor `--diff-tool` is explicitly given, so scripts that parse a specific output format cannot be broken by a variable inherited from a shell profile; an explicitly empty `--diff-tool ""` disables the external tool. There is no default command: without one, the built-in `--output` renderer is used.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Flags:
   -C, --context int                              output NUM lines of context around changes (default -1)
       --detailed-exitcode                        return a non-zero exit code when there are changes
       --devel                                    use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
       --disable-openapi-validation               disables rendered templates validation against the Kubernetes OpenAPI Schema
       --disable-validation                       disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install
       --dry-run string[="client"]                --dry-run, --dry-run=client, or --dry-run=true disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation. --dry-run=server enables the cluster access with helm-get and the lookup template function.
@@ -220,6 +221,35 @@ helm diff upgrade prod api ./charts/api --output structured
 
 When a kind is suppressed via `--suppress`, `changesSuppressed` is set to `true` and field details are omitted. Nested metadata such as labels show the container path (`metadata.labels`) and expose the label key through the `field` property (for example `app.kubernetes.io/version`).
 
+### External diff tool
+
+Set `--diff-tool` to a command and helm-diff renders the diff with that command instead of its built-in renderers. It writes the old and the new manifests into two temporary files and appends their paths as the last two arguments:
+
+```shell
+# any tool that accepts two file paths works
+helm diff upgrade api ./charts/api --diff-tool "diff -u -N"
+helm diff upgrade api ./charts/api --diff-tool "difft --language yaml"
+helm diff upgrade api ./charts/api --diff-tool "git --no-pager diff --no-index --color"
+helm diff upgrade api ./charts/api --diff-tool "delta --side-by-side"
+```
+
+The command can also be set through the `HELM_DIFF_TOOL` environment variable, which is convenient in a shell profile:
+
+```shell
+export HELM_DIFF_TOOL="difft --language yaml"
+helm diff upgrade api ./charts/api
+```
+
+`--diff-tool` takes precedence over `HELM_DIFF_TOOL`, and either one overrides `--output`. There is no default command: without one, the built-in `--output` renderer is used.
+
+Notes:
+
+- The command is executed directly, not through a shell, so pipes and shell expansion are not available. Wrap arguments containing spaces in quotes, for example `--diff-tool '"/opt/my tools/diff" -u'`. For anything more involved, point the flag at a wrapper script.
+- The manifests handed to the tool are the ones from the diff report, so `--suppress`, `--suppress-output-line-regex` and secret redaction still apply. Secrets are redacted unless `--show-secrets` is given, and suppressed kinds are replaced by a placeholder on both sides.
+- An exit code of `1` from the tool is treated as "differences found" and ignored. Other failures are reported on stderr without aborting helm-diff.
+- helm-diff's own exit code is unaffected by the tool: `--detailed-exitcode` still returns `2` based on the changes helm-diff detected.
+- `--context`/`-C` is not applied; use the equivalent option of the external tool (for example `diff -U3`).
+
 ## Commands:
 
 ### local:
@@ -249,6 +279,7 @@ Flags:
   -a, --api-versions stringArray                 Kubernetes api versions used for Capabilities.APIVersions
   -C, --context int                              output NUM lines of context around changes (default -1)
       --detailed-exitcode                        return a non-zero exit code when there are changes
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
       --enable-dns                               enable DNS lookups when rendering templates
   -D, --find-renames float32                     Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                                     help for local
@@ -329,6 +360,7 @@ Flags:
   -C, --context int                              output NUM lines of context around changes (default -1)
       --detailed-exitcode                        return a non-zero exit code when there are changes
       --devel                                    use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
       --disable-openapi-validation               disables rendered templates validation against the Kubernetes OpenAPI Schema
       --disable-validation                       disables rendered templates validation against the Kubernetes cluster you are currently pointing to. This is the same validation performed on an install
       --dry-run string[="client"]                --dry-run, --dry-run=client, or --dry-run=true disables cluster access and show diff as if it was install. Implies --install, --reset-values, and --disable-validation. --dry-run=server enables the cluster access with helm-get and the lookup template function.
@@ -396,6 +428,7 @@ Usage:
 Flags:
   -C, --context int                              output NUM lines of context around changes (default -1)
       --detailed-exitcode                        return a non-zero exit code when there are changes
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
   -D, --find-renames float32                     Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                                     help for release
       --include-tests                            enable the diffing of the helm test hooks
@@ -438,6 +471,7 @@ Flags:
   -C, --context int                              output NUM lines of context around changes (default -1)
       --show-secrets-decoded                     decode secret values in the output
       --detailed-exitcode                        return a non-zero exit code when there are changes
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
   -D, --find-renames float32                     Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                                     help for revision
       --include-tests                            enable the diffing of the helm test hooks
@@ -474,6 +508,7 @@ Examples:
 Flags:
   -C, --context int                              output NUM lines of context around changes (default -1)
       --detailed-exitcode                        return a non-zero exit code when there are changes
+      --diff-tool string                         command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments
   -D, --find-renames float32                     Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched
   -h, --help                                     help for rollback
       --include-tests                            enable the diffing of the helm test hooks

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ helm diff upgrade api ./charts/api
 Notes:
 
 - The command is executed directly, not through a shell, so pipes and shell expansion are not available. Wrap arguments containing spaces in quotes, for example `--diff-tool '"/opt/my tools/diff" -u'`; an unclosed quote is rejected with an error. For anything more involved, point the flag at a wrapper script.
-- Each resource in the temporary files is preceded by a `# Resource:`/`# Change:` header comment (change types: `ADD`, `REMOVE`, `MODIFY`, `OWNERSHIP`), because an external tool would otherwise have no way to show them.
+- Each resource in the temporary files is preceded by a `# Resource:`/`# Change:` header comment (change types: `ADD`, `REMOVE`, `MODIFY`, `OWNERSHIP`, and `MODIFY_SUPPRESSED` when the diff is empty after `--suppress-output-line-regex`), because an external tool would otherwise have no way to show them.
 - The manifests handed to the tool are the ones from the diff report, so `--suppress`, `--suppress-output-line-regex` and secret redaction still apply. Secrets are redacted unless `--show-secrets` is given; suppressed kinds — and entries whose diff is empty after `--suppress-output-line-regex` — are replaced by a placeholder on both sides.
 - The command must block until it has finished reading the two files. GUI tools that return immediately (for example `code --diff`) may find the temporary directory already deleted before they display it; make them wait (for example `code --wait --diff`) or wrap them in a script that waits.
 - There is no timeout around the command: a tool that never exits keeps helm-diff running.

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -25,4 +25,13 @@ func ProcessDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	if q, _ := f.GetBool("suppress-secrets"); q {
 		o.SuppressedKinds = append(o.SuppressedKinds, "Secret")
 	}
+
+	// HELM_DIFF_TOOL is a convenience for interactive use (e.g. set in a shell
+	// profile). An explicit flag is a deliberate choice and must win over it —
+	// explicit flag > environment > default — so that e.g. a CI job parsing
+	// `--output json` stdout cannot be silently broken by an inherited variable.
+	// An explicitly empty --diff-tool likewise disables the tool outright.
+	if f.Changed("diff-tool") || f.Changed("output") {
+		o.IgnoreDiffToolEnvVar()
+	}
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -14,6 +14,7 @@ func AddDiffOptions(f *pflag.FlagSet, o *diff.Options) {
 	f.StringArrayVar(&o.SuppressedKinds, "suppress", []string{}, "allows suppression of the kinds listed in the diff output (can specify multiple, like '--suppress Deployment --suppress Service')")
 	f.IntVarP(&o.OutputContext, "context", "C", -1, "output NUM lines of context around changes")
 	f.StringVar(&o.OutputFormat, "output", "diff", "Possible values: diff, simple, template, json, structured, dyff. When set to \"template\", use the env var HELM_DIFF_TPL to specify the template.")
+	f.StringVar(&o.DiffToolCommand, "diff-tool", "", "command used to compare the manifests instead of the built-in --output renderers (can also be set via the env var HELM_DIFF_TOOL). The old and the new manifest file paths are appended as the last two arguments")
 	f.BoolVar(&o.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 	f.Float32VarP(&o.FindRenames, "find-renames", "D", 0, "Enable rename detection if set to any value greater than 0. If specified, the value denotes the maximum fraction of changed content as lines added + removed compared to total lines in a diff for considering it a rename. Only objects of the same Kind are attempted to be matched")
 	f.StringArrayVar(&o.SuppressedOutputLineRegex, "suppress-output-line-regex", []string{}, "a regex to suppress diff output lines that match")

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -70,7 +70,6 @@ func TestProcessDiffOptionsDiffTool(t *testing.T) {
 	t.Run("an explicit --output wins over HELM_DIFF_TOOL", func(t *testing.T) {
 		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
 		o := processedOptions(t, "--output", "json")
-		require.Empty(t, o.DiffToolCommand)
 		require.False(t, o.DiffTool(),
 			"a script explicitly asking for --output json must not be surprised by an inherited environment variable")
 	})

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -74,15 +74,10 @@ func TestProcessDiffOptionsDiffTool(t *testing.T) {
 			"a script explicitly asking for --output json must not be surprised by an inherited environment variable")
 	})
 
-	t.Run("an explicit --diff-tool \"\" disables HELM_DIFF_TOOL", func(t *testing.T) {
-		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
-		o := processedOptions(t, "--diff-tool", "")
-		require.False(t, o.DiffTool(), "an explicitly empty --diff-tool is an explicit opt-out")
-	})
-
-	t.Run("an empty --diff-tool keeps the built-in output", func(t *testing.T) {
+	t.Run("an explicitly empty --diff-tool disables HELM_DIFF_TOOL", func(t *testing.T) {
 		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
 		o := processedOptions(t, "--diff-tool", "", "--output", "simple")
-		require.False(t, o.DiffTool())
+		require.False(t, o.DiffTool(), "an explicitly empty --diff-tool is an explicit opt-out")
+		require.Equal(t, "simple", o.OutputFormat, "the built-in renderer is used")
 	})
 }

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/databus23/helm-diff/v3/diff"
+)
+
+func processedOptions(t *testing.T, args ...string) diff.Options {
+	t.Helper()
+
+	var o diff.Options
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddDiffOptions(f, &o)
+	require.NoError(t, f.Parse(args))
+	ProcessDiffOptions(f, &o)
+
+	return o
+}
+
+func TestProcessDiffOptionsSuppressSecrets(t *testing.T) {
+	o := processedOptions(t, "--suppress-secrets")
+	require.Contains(t, o.SuppressedKinds, "Secret")
+}
+
+func TestAddDiffOptionsHasNoExternalOutputFormat(t *testing.T) {
+	var o diff.Options
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	AddDiffOptions(f, &o)
+
+	require.NotContains(t, f.Lookup("output").Usage, "external",
+		"--diff-tool is the only way to select an external tool")
+}
+
+func TestProcessDiffOptionsDiffTool(t *testing.T) {
+	t.Run("no external diff by default", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "")
+		o := processedOptions(t)
+		require.Equal(t, "diff", o.OutputFormat)
+		require.Empty(t, o.DiffToolCommand)
+		require.False(t, o.DiffTool())
+	})
+
+	t.Run("--diff-tool enables the external tool", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "")
+		o := processedOptions(t, "--diff-tool", "difft")
+		require.Equal(t, "difft", o.DiffToolCommand)
+		require.True(t, o.DiffTool())
+	})
+
+	t.Run("HELM_DIFF_TOOL enables the external tool", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
+		o := processedOptions(t)
+		require.True(t, o.DiffTool())
+	})
+
+	t.Run("the external tool overrides an explicit --output", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "")
+		o := processedOptions(t, "--diff-tool", "difft", "--output", "json")
+		require.Equal(t, "json", o.OutputFormat, "--output keeps its value")
+		require.True(t, o.DiffTool(), "but the external tool takes precedence")
+	})
+
+	t.Run("an empty --diff-tool keeps the built-in output", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "")
+		o := processedOptions(t, "--diff-tool", "", "--output", "simple")
+		require.False(t, o.DiffTool())
+	})
+}

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -26,13 +26,16 @@ func TestProcessDiffOptionsSuppressSecrets(t *testing.T) {
 	require.Contains(t, o.SuppressedKinds, "Secret")
 }
 
-func TestAddDiffOptionsHasNoExternalOutputFormat(t *testing.T) {
+func TestAddDiffOptionsOutputUsage(t *testing.T) {
 	var o diff.Options
 	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	AddDiffOptions(f, &o)
 
-	require.NotContains(t, f.Lookup("output").Usage, "external",
-		"--diff-tool is the only way to select an external tool")
+	// --output selects one of the built-in renderers; --diff-tool is the only
+	// way to select an external tool.
+	require.Contains(t, f.Lookup("output").Usage,
+		"diff, simple, template, json, structured, dyff")
+	require.Equal(t, "diff", f.Lookup("output").DefValue)
 }
 
 func TestProcessDiffOptionsDiffTool(t *testing.T) {
@@ -64,8 +67,22 @@ func TestProcessDiffOptionsDiffTool(t *testing.T) {
 		require.True(t, o.DiffTool(), "but the external tool takes precedence")
 	})
 
+	t.Run("an explicit --output wins over HELM_DIFF_TOOL", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
+		o := processedOptions(t, "--output", "json")
+		require.Empty(t, o.DiffToolCommand)
+		require.False(t, o.DiffTool(),
+			"a script explicitly asking for --output json must not be surprised by an inherited environment variable")
+	})
+
+	t.Run("an explicit --diff-tool \"\" disables HELM_DIFF_TOOL", func(t *testing.T) {
+		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
+		o := processedOptions(t, "--diff-tool", "")
+		require.False(t, o.DiffTool(), "an explicitly empty --diff-tool is an explicit opt-out")
+	})
+
 	t.Run("an empty --diff-tool keeps the built-in output", func(t *testing.T) {
-		t.Setenv(diff.DiffToolEnvVar, "")
+		t.Setenv(diff.DiffToolEnvVar, "colordiff -u")
 		o := processedOptions(t, "--diff-tool", "", "--output", "simple")
 		require.False(t, o.DiffTool())
 	})

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -35,11 +35,27 @@ type Options struct {
 
 const kindSecret = "Secret"
 
+const (
+	// Output formats accepted by setupReportFormat.
+	outputFormatSimple     = "simple"
+	outputFormatTemplate   = "template"
+	outputFormatJSON       = "json"
+	outputFormatStructured = "structured"
+	outputFormatDyff       = "dyff"
+
+	// Change types recorded on report entries.
+	changeTypeAdd              = "ADD"
+	changeTypeRemove           = "REMOVE"
+	changeTypeModify           = "MODIFY"
+	changeTypeModifySuppressed = "MODIFY_SUPPRESSED"
+	changeTypeOwnership        = "OWNERSHIP"
+)
+
 // StructuredOutput returns true when the structured JSON output is requested
 // except when using a diff tool, whose input is the line diffs that structured
 // output skips.
 func (o *Options) StructuredOutput() bool {
-	return o != nil && o.OutputFormat == "structured" && !o.DiffTool()
+	return o != nil && o.OutputFormat == outputFormatStructured && !o.DiffTool()
 }
 
 // DiffTool reports whether the diff is rendered by an external tool. Configuring a
@@ -87,7 +103,7 @@ func generateReport(oldIndex, newIndex map[string]*manifest.MappingResult, newOw
 
 	for name, diff := range newOwnedReleases {
 		diff := diffStrings(diff.OldRelease, diff.NewRelease, true)
-		report.addEntry(name, options.SuppressedKinds, "", 0, diff, "OWNERSHIP", nil)
+		report.addEntry(name, options.SuppressedKinds, "", 0, diff, changeTypeOwnership, nil)
 	}
 
 	for _, key := range sortedKeys(oldIndex) {
@@ -180,8 +196,8 @@ func doSuppress(report Report, suppressedOutputLineRegex []string) (Report, erro
 		switch {
 		case containsDiff:
 			diffRecords = diffs
-		case entry.ChangeType == "MODIFY":
-			entry.ChangeType = "MODIFY_SUPPRESSED"
+		case entry.ChangeType == changeTypeModify:
+			entry.ChangeType = changeTypeModifySuppressed
 		}
 
 		filteredReport.addEntry(entry.Key, entry.SuppressedKinds, entry.Kind, entry.Context, diffRecords, entry.ChangeType, entry.Structured)
@@ -285,7 +301,7 @@ func doDiff(report *Report, key string, oldContent *manifest.MappingResult, newC
 	var diffs []difflib.DiffRecord
 	switch {
 	case oldContent == nil:
-		changeType = "ADD"
+		changeType = changeTypeAdd
 		if newContent != nil {
 			subjectKind = newContent.Kind
 		}
@@ -294,14 +310,14 @@ func doDiff(report *Report, key string, oldContent *manifest.MappingResult, newC
 			diffs = diffMappingResults(emptyMapping, newContent, options.StripTrailingCR)
 		}
 	case newContent == nil:
-		changeType = "REMOVE"
+		changeType = changeTypeRemove
 		subjectKind = oldContent.Kind
 		if !options.StructuredOutput() {
 			emptyMapping := &manifest.MappingResult{}
 			diffs = diffMappingResults(oldContent, emptyMapping, options.StripTrailingCR)
 		}
 	default:
-		changeType = "MODIFY"
+		changeType = changeTypeModify
 		subjectKind = oldContent.Kind
 		if !options.StructuredOutput() {
 			diffs = diffMappingResults(oldContent, newContent, options.StripTrailingCR)
@@ -320,7 +336,7 @@ func doDiff(report *Report, key string, oldContent *manifest.MappingResult, newC
 			fmt.Fprintf(os.Stderr, "Warning: failed to build structured entry for %s (kind: %s, changeType: %s): %v\n",
 				key, subjectKind, changeType, err)
 		} else {
-			if changeType == "MODIFY" && !entry.ChangesSuppressed && len(entry.Changes) == 0 {
+			if changeType == changeTypeModify && !entry.ChangesSuppressed && len(entry.Changes) == 0 {
 				return
 			}
 			structured = entry

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -71,11 +71,12 @@ func (o *Options) DiffTool() bool {
 	return o != nil && o.configuredDiffToolCommand() != ""
 }
 
-// configuredDiffToolCommand resolves the command the external diff tool runs,
-// in one place, so that the decision to install the tool printer (DiffTool) and
-// the printer itself (via diffToolCommand) cannot drift apart. Once an explicit
-// flag supersedes HELM_DIFF_TOOL the environment is not consulted at all — not
-// even as a fallback for a blank --diff-tool.
+// configuredDiffToolCommand resolves the command for the external diff tool
+// in one place. The resolved value is what installs the tool printer
+// (DiffTool) and what the report carries to print time, so setup and rendering
+// cannot drift apart. Once an explicit flag supersedes HELM_DIFF_TOOL the
+// environment is not consulted at all — not even as a fallback for a blank
+// --diff-tool.
 func (o *Options) configuredDiffToolCommand() string {
 	if o.diffToolEnvIgnored {
 		return strings.TrimSpace(o.DiffToolCommand)
@@ -123,7 +124,7 @@ func ManifestReport(oldIndex, newIndex map[string]*manifest.MappingResult, optio
 }
 
 func generateReport(oldIndex, newIndex map[string]*manifest.MappingResult, newOwnedReleases map[string]OwnershipDiff, options *Options) (bool, *Report, error) {
-	report := Report{findRenames: options.FindRenames, diffToolCommand: options.DiffToolCommand}
+	report := Report{findRenames: options.FindRenames, diffToolCommand: options.configuredDiffToolCommand()}
 	if options.DiffTool() {
 		// A configured diff tool replaces whatever built-in output was selected.
 		setupDiffToolReport(&report)

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -31,12 +31,17 @@ type Options struct {
 	FindRenames               float32
 	SuppressedOutputLineRegex []string
 	DiffToolCommand           string
+
+	// diffToolEnvIgnored stops the HELM_DIFF_TOOL environment variable from
+	// being consulted, set when an explicit flag supersedes the environment.
+	diffToolEnvIgnored bool
 }
 
 const kindSecret = "Secret"
 
 const (
 	// Output formats accepted by setupReportFormat.
+	outputFormatDiff       = "diff"
 	outputFormatSimple     = "simple"
 	outputFormatTemplate   = "template"
 	outputFormatJSON       = "json"
@@ -61,7 +66,24 @@ func (o *Options) StructuredOutput() bool {
 // DiffTool reports whether the diff is rendered by an external tool. Configuring a
 // command is the only way to ask for it, and it overrides the built-in outputs.
 func (o *Options) DiffTool() bool {
-	return o != nil && diffToolCommand(o.DiffToolCommand) != ""
+	if o == nil {
+		return false
+	}
+	if strings.TrimSpace(o.DiffToolCommand) != "" {
+		return true
+	}
+	return !o.diffToolEnvIgnored && strings.TrimSpace(os.Getenv(DiffToolEnvVar)) != ""
+}
+
+// IgnoreDiffToolEnvVar stops the HELM_DIFF_TOOL environment variable from being
+// consulted. It implements the "explicit flag over environment" precedence: a
+// command requested with --diff-tool is authoritative even when empty, and an
+// explicitly requested built-in output must not be silently overridden by a
+// variable inherited e.g. from a shell profile.
+func (o *Options) IgnoreDiffToolEnvVar() {
+	if o != nil {
+		o.diffToolEnvIgnored = true
+	}
 }
 
 type OwnershipDiff struct {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -63,16 +63,25 @@ func (o *Options) StructuredOutput() bool {
 	return o != nil && o.OutputFormat == outputFormatStructured && !o.DiffTool()
 }
 
-// DiffTool reports whether the diff is rendered by an external tool. Configuring a
-// command is the only way to ask for it, and it overrides the built-in outputs.
+// DiffTool reports whether the diff is rendered by an external tool, requested
+// either with --diff-tool or through the HELM_DIFF_TOOL environment variable.
+// The external tool overrides the built-in outputs, except that an explicit
+// flag supersedes the environment variable (see IgnoreDiffToolEnvVar).
 func (o *Options) DiffTool() bool {
-	if o == nil {
-		return false
+	return o != nil && o.configuredDiffToolCommand() != ""
+}
+
+// configuredDiffToolCommand resolves the command the external diff tool runs,
+// in one place, so that the decision to install the tool printer (DiffTool) and
+// the printer itself (via diffToolCommand) cannot drift apart. Once an explicit
+// flag supersedes HELM_DIFF_TOOL the environment is not consulted at all — not
+// even as a fallback for a blank --diff-tool.
+func (o *Options) configuredDiffToolCommand() string {
+	if o.diffToolEnvIgnored {
+		return strings.TrimSpace(o.DiffToolCommand)
 	}
-	if strings.TrimSpace(o.DiffToolCommand) != "" {
-		return true
-	}
-	return !o.diffToolEnvIgnored && strings.TrimSpace(os.Getenv(DiffToolEnvVar)) != ""
+
+	return diffToolCommand(o.DiffToolCommand)
 }
 
 // IgnoreDiffToolEnvVar stops the HELM_DIFF_TOOL environment variable from being

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -30,13 +30,22 @@ type Options struct {
 	SuppressedKinds           []string
 	FindRenames               float32
 	SuppressedOutputLineRegex []string
+	DiffToolCommand           string
 }
 
 const kindSecret = "Secret"
 
-// StructuredOutput returns true when the structured JSON output is requested.
+// StructuredOutput returns true when the structured JSON output is requested
+// except when using a diff tool, whose input is the line diffs that structured
+// output skips.
 func (o *Options) StructuredOutput() bool {
-	return o != nil && o.OutputFormat == "structured"
+	return o != nil && o.OutputFormat == "structured" && !o.DiffTool()
+}
+
+// DiffTool reports whether the diff is rendered by an external tool. Configuring a
+// command is the only way to ask for it, and it overrides the built-in outputs.
+func (o *Options) DiffTool() bool {
+	return o != nil && diffToolCommand(o.DiffToolCommand) != ""
 }
 
 type OwnershipDiff struct {
@@ -67,8 +76,13 @@ func ManifestReport(oldIndex, newIndex map[string]*manifest.MappingResult, optio
 }
 
 func generateReport(oldIndex, newIndex map[string]*manifest.MappingResult, newOwnedReleases map[string]OwnershipDiff, options *Options) (bool, *Report, error) {
-	report := Report{findRenames: options.FindRenames}
-	report.setupReportFormat(options.OutputFormat)
+	report := Report{findRenames: options.FindRenames, diffToolCommand: options.DiffToolCommand}
+	if options.DiffTool() {
+		// A configured diff tool replaces whatever built-in output was selected.
+		setupDiffToolReport(&report)
+	} else {
+		report.setupReportFormat(options.OutputFormat)
+	}
 	var possiblyRemoved []string
 
 	for name, diff := range newOwnedReleases {
@@ -121,7 +135,8 @@ func doSuppress(report Report, suppressedOutputLineRegex []string) (Report, erro
 	}
 
 	filteredReport := Report{
-		findRenames: report.findRenames,
+		findRenames:     report.findRenames,
+		diffToolCommand: report.diffToolCommand,
 	}
 	filteredReport.format = report.format
 	filteredReport.Entries = []ReportEntry{}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -278,7 +278,7 @@ annotations:
 
 	t.Run("OnChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -297,7 +297,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{"apiVersion"}}
 
 		if changesSeen := Manifests(specBeta, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -316,7 +316,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppressAll", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{"apiVersion"}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -328,7 +328,7 @@ annotations:
 
 	t.Run("OnChangeRename", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamed, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -349,7 +349,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndUpdate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndUpdated, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -371,7 +371,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAdded", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -395,7 +395,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAddedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{"app: "}}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -418,7 +418,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -442,7 +442,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemovedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{"app: "}}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -465,7 +465,7 @@ annotations:
 
 	t.Run("OnNoChange", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -476,7 +476,7 @@ annotations:
 
 	t.Run("OnChangeRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specRelease, nil, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -494,7 +494,7 @@ annotations:
 
 	t.Run("OnChangeRemovedWithResourcePolicyKeep", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specReleaseKeep, nil, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -505,7 +505,7 @@ annotations:
 
 	t.Run("OnChangeSimple", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "simple", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -518,7 +518,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeSimple", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "simple", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
@@ -528,7 +528,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "template", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -546,7 +546,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeJSON", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"json", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "json", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -564,7 +564,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "template", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -576,7 +576,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		os.Setenv("HELM_DIFF_TPL", "testdata/customTemplate.tpl")
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
+		diffOptions := Options{OutputFormat: "template", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.0, SuppressedOutputLineRegex: []string{}}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -1134,7 +1134,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithByteData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: false, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}} // NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithByteData, specSecretWithByteDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -1159,7 +1159,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithStringData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: false, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}} // NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithStringData, specSecretWithStringDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -1284,7 +1284,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithoutSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}} // NOTE: ShowSecrets = false
 
 		newOwnedReleases := map[string]OwnershipDiff{
 			"default, foobar, ConfigMap (v1)": {
@@ -1304,7 +1304,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
+		diffOptions := Options{OutputFormat: "diff", OutputContext: 10, StripTrailingCR: false, ShowSecrets: true, ShowSecretsDecoded: false, SuppressedKinds: []string{}, FindRenames: 0.5, SuppressedOutputLineRegex: []string{}} // NOTE: ShowSecrets = false
 
 		specNew := map[string]*manifest.MappingResult{
 			"default, foobar, ConfigMap (v1)": {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -278,7 +278,7 @@ annotations:
 
 	t.Run("OnChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -297,7 +297,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}, ""}
 
 		if changesSeen := Manifests(specBeta, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -316,7 +316,7 @@ annotations:
 
 	t.Run("OnChangeWithSuppressAll", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{"apiVersion"}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -328,7 +328,7 @@ annotations:
 
 	t.Run("OnChangeRename", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamed, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -349,7 +349,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndUpdate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndUpdated, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -371,7 +371,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAdded", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -395,7 +395,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndAddedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}, ""}
 
 		if changesSeen := Manifests(specReleaseSpec, specReleaseRenamedAndAdded, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -418,7 +418,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -442,7 +442,7 @@ annotations:
 
 	t.Run("OnChangeRenameAndRemovedWithPartialSuppress", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{"app: "}, ""}
 
 		if changesSeen := Manifests(specReleaseRenamedAndAdded, specReleaseSpec, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -465,7 +465,7 @@ annotations:
 
 	t.Run("OnNoChange", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -476,7 +476,7 @@ annotations:
 
 	t.Run("OnChangeRemoved", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""}
 
 		if changesSeen := Manifests(specRelease, nil, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -494,7 +494,7 @@ annotations:
 
 	t.Run("OnChangeRemovedWithResourcePolicyKeep", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specReleaseKeep, nil, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -505,7 +505,7 @@ annotations:
 
 	t.Run("OnChangeSimple", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -518,7 +518,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeSimple", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"simple", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
 		}
@@ -528,7 +528,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -546,7 +546,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnChangeJSON", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"json", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"json", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -564,7 +564,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 
 	t.Run("OnNoChangeTemplate", func(t *testing.T) {
 		var buf2 bytes.Buffer
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specRelease, specRelease, &diffOptions, &buf2); changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -576,7 +576,7 @@ Plan: 0 to add, 1 to change, 0 to destroy, 0 to change ownership.
 	t.Run("OnChangeCustomTemplate", func(t *testing.T) {
 		var buf1 bytes.Buffer
 		os.Setenv("HELM_DIFF_TPL", "testdata/customTemplate.tpl")
-		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}}
+		diffOptions := Options{"template", 10, false, true, false, []string{}, 0.0, []string{}, ""}
 
 		if changesSeen := Manifests(specBeta, specRelease, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `false` to indicate that it has NOT seen any change(s), but was `true`")
@@ -1134,7 +1134,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithByteData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}} // NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithByteData, specSecretWithByteDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -1159,7 +1159,7 @@ stringData:
 
 	t.Run("OnChangeSecretWithStringData", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}} // NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, false, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
 
 		if changesSeen := Manifests(specSecretWithStringData, specSecretWithStringDataChanged, &diffOptions, &buf1); !changesSeen {
 			t.Error("Unexpected return value from Manifests: Expected the return value to be `true` to indicate that it has seen any change(s), but was `false`")
@@ -1284,7 +1284,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithoutSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}} // NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
 
 		newOwnedReleases := map[string]OwnershipDiff{
 			"default, foobar, ConfigMap (v1)": {
@@ -1304,7 +1304,7 @@ data:
 
 	t.Run("OnChangeOwnershipWithSpecChange", func(t *testing.T) {
 		var buf1 bytes.Buffer
-		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}} // NOTE: ShowSecrets = false
+		diffOptions := Options{"diff", 10, false, true, false, []string{}, 0.5, []string{}, ""} // NOTE: ShowSecrets = false
 
 		specNew := map[string]*manifest.MappingResult{
 			"default, foobar, ConfigMap (v1)": {

--- a/diff/difftool.go
+++ b/diff/difftool.go
@@ -1,0 +1,174 @@
+package diff
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aryann/difflib"
+)
+
+const (
+	// DiffToolEnvVar holds the diff tool command line when no flag is given.
+	// Setting it is by itself a request to render the diff with that command.
+	DiffToolEnvVar = "HELM_DIFF_TOOL"
+)
+
+// diffToolCommand returns the configured command, falling back to the
+// environment variable. There is deliberately no default: helm-diff never picks a
+// diff tool on the user's behalf, so an unset command is a configuration error
+// rather than an invitation to guess.
+func diffToolCommand(configured string) string {
+	if strings.TrimSpace(configured) != "" {
+		return configured
+	}
+
+	return strings.TrimSpace(os.Getenv(DiffToolEnvVar))
+}
+
+// splitDiffToolCommand splits a command line into a command and its arguments.
+// Whitespace separates arguments unless quoted, so that paths containing spaces can
+// be expressed as `"/opt/my tools/diff" -u`. The result is executed directly rather
+// than through a shell, so the generated file paths cannot be expanded or injected.
+func splitDiffToolCommand(command string) []string {
+	var (
+		args    []string
+		current strings.Builder
+		quote   rune
+		started bool
+	)
+
+	for _, r := range command {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			started = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			if started {
+				args = append(args, current.String())
+				current.Reset()
+				started = false
+			}
+		default:
+			current.WriteRune(r)
+			started = true
+		}
+	}
+
+	if started {
+		args = append(args, current.String())
+	}
+
+	return args
+}
+
+func setupDiffToolReport(r *Report) {
+	r.format.output = printDiffToolReport
+}
+
+// printDiffToolReport writes both sides of the report to temporary files and
+// appends their paths as the last two arguments of the diff tool command,
+// streaming its output to `to`.
+func printDiffToolReport(r *Report, to io.Writer) {
+	if len(r.Entries) == 0 {
+		return
+	}
+
+	args := splitDiffToolCommand(diffToolCommand(r.diffToolCommand))
+	if len(args) == 0 {
+		// Unreachable: this printer is only installed once a command is configured.
+		fmt.Fprintf(os.Stderr, "Error: no diff tool configured\n")
+		return
+	}
+
+	oldFile, newFile, cleanup, err := createDiffToolFiles()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: unable to create temporary files for the diff tool: %v\n", err)
+		return
+	}
+	defer cleanup()
+
+	if err := writeDiffToolSides(r, oldFile, newFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: unable to write manifests for the diff tool: %v\n", err)
+		return
+	}
+
+	cmd := exec.Command(args[0], append(args[1:], oldFile, newFile)...)
+	cmd.Stdout = to
+	cmd.Stderr = os.Stderr
+
+	// Exit code 1 conventionally means "differences found", the expected case here.
+	// Other failures are reported but must not abort helm-diff, whose own exit code
+	// is derived from the report.
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Error: diff tool %q failed: %v\n", strings.Join(args, " "), err)
+	}
+}
+
+func createDiffToolFiles() (oldFile, newFile string, cleanup func(), err error) {
+	// Stable basenames in a private directory: diff tools label their output
+	// with the file names, which randomized temp names would make unreadable.
+	dir, err := os.MkdirTemp("", "helm-diff-tool")
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	return filepath.Join(dir, "current.yaml"),
+		filepath.Join(dir, "new.yaml"),
+		func() { _ = os.RemoveAll(dir) },
+		nil
+}
+
+// writeDiffToolSides reconstructs the old and the new manifests from the report
+// entries rather than from the raw manifests, which keeps secret redaction and line
+// suppression in effect for whatever the diff tool receives.
+func writeDiffToolSides(r *Report, oldPath, newPath string) error {
+	var current, next strings.Builder
+
+	for _, entry := range r.Entries {
+		header := "---\n# Source: " + entry.Key + "\n"
+		_, _ = current.WriteString(header)
+		_, _ = next.WriteString(header)
+
+		if containsKind(entry.SuppressedKinds, entry.Kind) {
+			// Identical placeholder on both sides: the tool must report no change
+			// rather than receive the suppressed content.
+			placeholder := fmt.Sprintf("# Changes suppressed on sensitive content of type %s\n", entry.Kind)
+			_, _ = current.WriteString(placeholder)
+			_, _ = next.WriteString(placeholder)
+			continue
+		}
+
+		for _, record := range entry.Diffs {
+			switch record.Delta {
+			case difflib.Common:
+				_, _ = current.WriteString(record.Payload + "\n")
+				_, _ = next.WriteString(record.Payload + "\n")
+			case difflib.LeftOnly:
+				_, _ = current.WriteString(record.Payload + "\n")
+			case difflib.RightOnly:
+				_, _ = next.WriteString(record.Payload + "\n")
+			}
+		}
+	}
+
+	if err := os.WriteFile(oldPath, []byte(current.String()), 0o600); err != nil {
+		return err
+	}
+
+	return os.WriteFile(newPath, []byte(next.String()), 0o600)
+}

--- a/diff/difftool.go
+++ b/diff/difftool.go
@@ -34,7 +34,9 @@ func diffToolCommand(configured string) string {
 // Whitespace separates arguments unless quoted, so that paths containing spaces can
 // be expressed as `"/opt/my tools/diff" -u`. The result is executed directly rather
 // than through a shell, so the generated file paths cannot be expanded or injected.
-func splitDiffToolCommand(command string) []string {
+// An unclosed quote is an error: silently dropping it would hand the tool a
+// different command line than the user typed.
+func splitDiffToolCommand(command string) ([]string, error) {
 	var (
 		args    []string
 		current strings.Builder
@@ -65,11 +67,15 @@ func splitDiffToolCommand(command string) []string {
 		}
 	}
 
+	if quote != 0 {
+		return nil, fmt.Errorf("unclosed %q quote in diff tool command %q", quote, command)
+	}
+
 	if started {
 		args = append(args, current.String())
 	}
 
-	return args
+	return args, nil
 }
 
 func setupDiffToolReport(r *Report) {
@@ -84,7 +90,11 @@ func printDiffToolReport(r *Report, to io.Writer) {
 		return
 	}
 
-	args := splitDiffToolCommand(diffToolCommand(r.diffToolCommand))
+	args, err := splitDiffToolCommand(diffToolCommand(r.diffToolCommand))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return
+	}
 	if len(args) == 0 {
 		// Unreachable: this printer is only installed once a command is configured.
 		fmt.Fprintf(os.Stderr, "Error: no diff tool configured\n")
@@ -121,13 +131,14 @@ func printDiffToolReport(r *Report, to io.Writer) {
 
 func createDiffToolFiles() (oldFile, newFile string, cleanup func(), err error) {
 	// Stable basenames in a private directory: diff tools label their output
-	// with the file names, which randomized temp names would make unreadable.
+	// with the file names, so old.yaml/new.yaml pair up naturally where random
+	// temp names would be unreadable.
 	dir, err := os.MkdirTemp("", "helm-diff-tool")
 	if err != nil {
 		return "", "", nil, err
 	}
 
-	return filepath.Join(dir, "current.yaml"),
+	return filepath.Join(dir, "old.yaml"),
 		filepath.Join(dir, "new.yaml"),
 		func() { _ = os.RemoveAll(dir) },
 		nil
@@ -140,28 +151,41 @@ func writeDiffToolSides(r *Report, oldPath, newPath string) error {
 	var current, next strings.Builder
 
 	for _, entry := range r.Entries {
-		header := "---\n# Source: " + entry.Key + "\n"
+		// The tool only sees file content, so a header comment carries what the
+		// built-in output would print around the diff: the resource the entry
+		// refers to (the manifest content keeps its own "# Source:" template
+		// path) and the change type, which would otherwise be invisible to the
+		// tool user (ADD, REMOVE, MODIFY, ...).
+		header := fmt.Sprintf("---\n# Resource: %s\n# Change: %s\n", entry.Key, entry.ChangeType)
 		_, _ = current.WriteString(header)
 		_, _ = next.WriteString(header)
 
-		if containsKind(entry.SuppressedKinds, entry.Kind) {
+		switch {
+		case containsKind(entry.SuppressedKinds, entry.Kind):
 			// Identical placeholder on both sides: the tool must report no change
 			// rather than receive the suppressed content.
 			placeholder := fmt.Sprintf("# Changes suppressed on sensitive content of type %s\n", entry.Kind)
 			_, _ = current.WriteString(placeholder)
 			_, _ = next.WriteString(placeholder)
-			continue
-		}
-
-		for _, record := range entry.Diffs {
-			switch record.Delta {
-			case difflib.Common:
-				_, _ = current.WriteString(record.Payload + "\n")
-				_, _ = next.WriteString(record.Payload + "\n")
-			case difflib.LeftOnly:
-				_, _ = current.WriteString(record.Payload + "\n")
-			case difflib.RightOnly:
-				_, _ = next.WriteString(record.Payload + "\n")
+		case len(entry.Diffs) == 0:
+			// Every changed line was removed by --suppress-output-line-regex (such
+			// entries are flipped to MODIFY_SUPPRESSED, or kept as ADD/REMOVE with
+			// empty diffs). Without a placeholder the tool would report no difference
+			// at all while helm-diff still exits with "changes found".
+			placeholder := "# Changes suppressed by --suppress-output-line-regex\n"
+			_, _ = current.WriteString(placeholder)
+			_, _ = next.WriteString(placeholder)
+		default:
+			for _, record := range entry.Diffs {
+				switch record.Delta {
+				case difflib.Common:
+					_, _ = current.WriteString(record.Payload + "\n")
+					_, _ = next.WriteString(record.Payload + "\n")
+				case difflib.LeftOnly:
+					_, _ = current.WriteString(record.Payload + "\n")
+				case difflib.RightOnly:
+					_, _ = next.WriteString(record.Payload + "\n")
+				}
 			}
 		}
 	}

--- a/diff/difftool.go
+++ b/diff/difftool.go
@@ -168,10 +168,11 @@ func writeDiffToolSides(r *Report, oldPath, newPath string) error {
 			_, _ = current.WriteString(placeholder)
 			_, _ = next.WriteString(placeholder)
 		case len(entry.Diffs) == 0:
-			// Every changed line was removed by --suppress-output-line-regex (such
-			// entries are flipped to MODIFY_SUPPRESSED, or kept as ADD/REMOVE with
-			// empty diffs). Without a placeholder the tool would report no difference
-			// at all while helm-diff still exits with "changes found".
+			// Every changed line was removed by --suppress-output-line-regex: such
+			// entries arrive either flipped to MODIFY_SUPPRESSED or, for the other
+			// change types (ADD/REMOVE/OWNERSHIP are not rewritten), with empty
+			// diffs. Without a placeholder the tool would report no difference at
+			// all while helm-diff still exits with "changes found".
 			placeholder := "# Changes suppressed by --suppress-output-line-regex\n"
 			_, _ = current.WriteString(placeholder)
 			_, _ = next.WriteString(placeholder)

--- a/diff/difftool.go
+++ b/diff/difftool.go
@@ -18,10 +18,13 @@ const (
 	DiffToolEnvVar = "HELM_DIFF_TOOL"
 )
 
-// diffToolCommand returns the configured command, falling back to the
-// environment variable. There is deliberately no default: helm-diff never picks a
-// diff tool on the user's behalf, so an unset command is a configuration error
-// rather than an invitation to guess.
+// diffToolCommand merges the --diff-tool flag with the HELM_DIFF_TOOL
+// environment variable, the flag winning. Callers that must honor the
+// explicit-flag precedence use Options.configuredDiffToolCommand instead;
+// this free function deliberately knows nothing about that. There is
+// deliberately no default: helm-diff never picks a diff tool on the user's
+// behalf, so an unset command is a configuration error rather than an
+// invitation to guess.
 func diffToolCommand(configured string) string {
 	if strings.TrimSpace(configured) != "" {
 		return configured
@@ -90,7 +93,7 @@ func printDiffToolReport(r *Report, to io.Writer) {
 		return
 	}
 
-	args, err := splitDiffToolCommand(diffToolCommand(r.diffToolCommand))
+	args, err := splitDiffToolCommand(r.diffToolCommand)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return

--- a/diff/difftool_test.go
+++ b/diff/difftool_test.go
@@ -1,0 +1,356 @@
+package diff
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aryann/difflib"
+	"github.com/stretchr/testify/require"
+
+	"github.com/databus23/helm-diff/v3/manifest"
+)
+
+func TestSplitDiffToolCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			command:  "   ",
+			expected: nil,
+		},
+		{
+			name:     "simple",
+			command:  "diff -u -N",
+			expected: []string{"diff", "-u", "-N"},
+		},
+		{
+			name:     "collapses repeated whitespace",
+			command:  "  diff \t -u  ",
+			expected: []string{"diff", "-u"},
+		},
+		{
+			name:     "double quoted argument keeps spaces",
+			command:  `"/opt/my tools/diff" --color=always`,
+			expected: []string{"/opt/my tools/diff", "--color=always"},
+		},
+		{
+			name:     "single quoted argument keeps spaces",
+			command:  `'/opt/my tools/diff' -u`,
+			expected: []string{"/opt/my tools/diff", "-u"},
+		},
+		{
+			name:     "quotes inside an argument",
+			command:  `git --no-pager diff --src-prefix="a b/"`,
+			expected: []string{"git", "--no-pager", "diff", "--src-prefix=a b/"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, splitDiffToolCommand(tt.command))
+		})
+	}
+}
+
+func TestDiffToolCommandResolution(t *testing.T) {
+	t.Run("empty when nothing is configured", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "")
+		require.Empty(t, diffToolCommand(""))
+	})
+
+	t.Run("environment variable is used when no command is given", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "colordiff -u")
+		require.Equal(t, "colordiff -u", diffToolCommand(""))
+	})
+
+	t.Run("explicit command wins over the environment variable", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "colordiff -u")
+		require.Equal(t, "difft", diffToolCommand("difft"))
+	})
+}
+
+func TestWriteDiffToolSides(t *testing.T) {
+	report := &Report{
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: "MODIFY",
+				Diffs: []difflib.DiffRecord{
+					{Payload: "kind: Deployment", Delta: difflib.Common},
+					{Payload: "  replicas: 2", Delta: difflib.LeftOnly},
+					{Payload: "  replicas: 3", Delta: difflib.RightOnly},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old")
+	newPath := filepath.Join(dir, "new")
+	require.NoError(t, writeDiffToolSides(report, oldPath, newPath))
+
+	oldContent, err := os.ReadFile(oldPath)
+	require.NoError(t, err)
+	newContent, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "---\n# Source: default, nginx, Deployment (apps)\nkind: Deployment\n  replicas: 2\n", string(oldContent))
+	require.Equal(t, "---\n# Source: default, nginx, Deployment (apps)\nkind: Deployment\n  replicas: 3\n", string(newContent))
+}
+
+func TestWriteDiffToolSidesSuppressedKind(t *testing.T) {
+	report := &Report{
+		Entries: []ReportEntry{
+			{
+				Key:             "default, mysecret, Secret (v1)",
+				Kind:            "Secret",
+				SuppressedKinds: []string{"Secret"},
+				ChangeType:      "MODIFY",
+				Diffs: []difflib.DiffRecord{
+					{Payload: "kind: Secret", Delta: difflib.Common},
+					{Payload: "  password: aGkK", Delta: difflib.LeftOnly},
+					{Payload: "  password: Ynll", Delta: difflib.RightOnly},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old")
+	newPath := filepath.Join(dir, "new")
+	require.NoError(t, writeDiffToolSides(report, oldPath, newPath))
+
+	oldContent, err := os.ReadFile(oldPath)
+	require.NoError(t, err)
+	newContent, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(oldContent), "aGkK", "suppressed kinds must not leak their content")
+	require.NotContains(t, string(newContent), "Ynll", "suppressed kinds must not leak their content")
+	require.Contains(t, string(oldContent), "Changes suppressed on sensitive content of type Secret")
+	require.Equal(t, string(oldContent), string(newContent), "suppressed entries must be identical on both sides")
+}
+
+func TestPrintDiffToolReport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX diff implementation")
+	}
+
+	report := &Report{
+		diffToolCommand: "diff -u -N",
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: "MODIFY",
+				Diffs: []difflib.DiffRecord{
+					{Payload: "kind: Deployment", Delta: difflib.Common},
+					{Payload: "  replicas: 2", Delta: difflib.LeftOnly},
+					{Payload: "  replicas: 3", Delta: difflib.RightOnly},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printDiffToolReport(report, &buf)
+
+	output := buf.String()
+	require.Contains(t, output, "-  replicas: 2")
+	require.Contains(t, output, "+  replicas: 3")
+}
+
+func TestPrintDiffToolReportEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX diff implementation")
+	}
+
+	report := &Report{diffToolCommand: "diff -u -N", Entries: []ReportEntry{}}
+
+	var buf bytes.Buffer
+	printDiffToolReport(report, &buf)
+
+	require.Empty(t, buf.String())
+}
+
+func TestPrintDiffToolReportPassesBothFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX shell")
+	}
+
+	report := &Report{
+		diffToolCommand: "echo",
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: "MODIFY",
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printDiffToolReport(report, &buf)
+
+	fields := bytes.Fields(buf.Bytes())
+	require.Len(t, fields, 2, "the external command must receive exactly the two file paths")
+	require.NotEqual(t, string(fields[0]), string(fields[1]), "both sides must be distinct files")
+}
+
+func TestManifestsDiffToolOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX diff implementation")
+	}
+	t.Setenv(DiffToolEnvVar, "")
+
+	old := map[string]*manifest.MappingResult{
+		"default, nginx, Deployment (apps)": {
+			Name:    "default, nginx, Deployment (apps)",
+			Kind:    "Deployment",
+			Content: "kind: Deployment\nspec:\n  replicas: 2\n",
+		},
+	}
+	updated := map[string]*manifest.MappingResult{
+		"default, nginx, Deployment (apps)": {
+			Name:    "default, nginx, Deployment (apps)",
+			Kind:    "Deployment",
+			Content: "kind: Deployment\nspec:\n  replicas: 3\n",
+		},
+	}
+
+	t.Run("the command alone selects the external tool", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := &Options{OutputFormat: "diff", DiffToolCommand: "diff -u -N"}
+
+		require.True(t, Manifests(old, updated, opts, &buf))
+		require.Contains(t, buf.String(), "-  replicas: 2")
+		require.Contains(t, buf.String(), "+  replicas: 3")
+		require.Contains(t, buf.String(), "@@", "expected unified diff output from the external tool")
+	})
+
+	t.Run("the environment variable alone selects the external tool", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "diff -u -N")
+		var buf bytes.Buffer
+		opts := &Options{OutputFormat: "diff"}
+
+		require.True(t, Manifests(old, updated, opts, &buf))
+		require.Contains(t, buf.String(), "@@")
+	})
+
+	t.Run("the external tool wins over every built-in output", func(t *testing.T) {
+		for _, format := range []string{"diff", "simple", "json", "template", "structured", "dyff"} {
+			var buf bytes.Buffer
+			opts := &Options{OutputFormat: format, DiffToolCommand: "diff -u -N"}
+
+			require.True(t, Manifests(old, updated, opts, &buf))
+			require.Contains(t, buf.String(), "@@",
+				"output %q must be overridden by the external diff command", format)
+		}
+	})
+
+	t.Run("built-in output is used when no command is configured", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := &Options{OutputFormat: "simple"}
+
+		require.True(t, Manifests(old, updated, opts, &buf))
+		require.Contains(t, buf.String(), "to be changed.")
+		require.NotContains(t, buf.String(), "@@")
+	})
+
+	t.Run("honors suppress-output-line-regex", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := &Options{
+			DiffToolCommand:           "diff -u -N",
+			SuppressedOutputLineRegex: []string{"replicas"},
+		}
+
+		Manifests(old, updated, opts, &buf)
+		require.NotContains(t, buf.String(), "replicas")
+	})
+
+	t.Run("no output when there are no changes", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := &Options{DiffToolCommand: "diff -u -N"}
+
+		require.False(t, Manifests(old, old, opts, &buf))
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestDiffToolEnabled(t *testing.T) {
+	t.Run("disabled when nothing is configured", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "")
+		require.False(t, (&Options{OutputFormat: "diff"}).DiffTool())
+	})
+
+	t.Run("enabled by the command", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "")
+		require.True(t, (&Options{DiffToolCommand: "difft"}).DiffTool())
+	})
+
+	t.Run("enabled by the environment variable", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "difft")
+		require.True(t, (&Options{}).DiffTool())
+	})
+
+	t.Run("a blank command does not enable it", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "   ")
+		require.False(t, (&Options{DiffToolCommand: "  "}).DiffTool())
+	})
+
+	t.Run("structured output is disabled while an external tool is used", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "")
+		opts := &Options{OutputFormat: "structured", DiffToolCommand: "difft"}
+		require.True(t, opts.DiffTool())
+		require.False(t, opts.StructuredOutput(),
+			"the external tool needs the line diffs that structured output skips")
+	})
+}
+
+func TestPrintDiffToolReportNoCommand(t *testing.T) {
+	t.Setenv(DiffToolEnvVar, "")
+
+	report := &Report{
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: "MODIFY",
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NotPanics(t, func() { printDiffToolReport(report, &buf) })
+	require.Empty(t, buf.String(), "without a command there is nothing to render")
+}
+
+func TestPrintDiffToolReportCommandFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX shell")
+	}
+
+	report := &Report{
+		diffToolCommand: "helm-diff-no-such-external-tool",
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: "MODIFY",
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NotPanics(t, func() { printDiffToolReport(report, &buf) })
+}

--- a/diff/difftool_test.go
+++ b/diff/difftool_test.go
@@ -2,9 +2,11 @@ package diff
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/aryann/difflib"
@@ -13,11 +15,96 @@ import (
 	"github.com/databus23/helm-diff/v3/manifest"
 )
 
+// The printDiffToolReport tests below re-run this test binary as a stand-in for
+// the external diff tool (the TestHelperProcess pattern from os/exec), so they do
+// not depend on POSIX tools like diff or echo and also run on Windows.
+const (
+	diffToolHelperEnv      = "GO_WANT_DIFF_TOOL_HELPER"
+	diffToolHelperBehavior = "HELM_DIFF_TOOL_HELPER_BEHAVIOR"
+)
+
+// diffToolHelperCommand returns the command line for the stand-in diff tool and
+// selects its behavior, which is implemented by TestDiffToolHelperProcess below.
+func diffToolHelperCommand(t *testing.T, behavior string) string {
+	t.Helper()
+	t.Setenv(diffToolHelperEnv, "1")
+	t.Setenv(diffToolHelperBehavior, behavior)
+
+	binary, err := os.Executable()
+	require.NoError(t, err)
+
+	return fmt.Sprintf("%q -test.run=^TestDiffToolHelperProcess$ --", binary)
+}
+
+// TestDiffToolHelperProcess is not a real test. It is the implementation of the
+// stand-in diff tool: invoked as `<test binary> -test.run=... -- <old> <new>`,
+// it selects its behavior via HELM_DIFF_TOOL_HELPER_BEHAVIOR.
+func TestDiffToolHelperProcess(t *testing.T) {
+	if os.Getenv(diffToolHelperEnv) != "1" {
+		return
+	}
+
+	// Everything after "--" is the file paths appended by printDiffToolReport.
+	var files []string
+	for i, arg := range os.Args {
+		if arg == "--" {
+			files = os.Args[i+1:]
+			break
+		}
+	}
+
+	switch os.Getenv(diffToolHelperBehavior) {
+	case "cat": // print the contents of both files, like `cat old new`
+		for _, file := range files {
+			content, err := os.ReadFile(file)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "helper cat: %v\n", err)
+				os.Exit(3)
+			}
+			_, _ = os.Stdout.Write(content)
+		}
+	case "args": // print the file arguments, one per line
+		for _, file := range files {
+			fmt.Println(file)
+		}
+	case "diff": // differences found: print to stdout and exit 1 like diff tools do
+		fmt.Println("helper: differences found")
+		os.Exit(1)
+	case "fail": // simulate a broken tool
+		fmt.Fprintln(os.Stderr, "helper: boom")
+		os.Exit(3)
+	}
+
+	os.Exit(0)
+}
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns what
+// was written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stderr = writer
+	defer func() { os.Stderr = original }()
+
+	fn()
+
+	require.NoError(t, writer.Close())
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	return string(content)
+}
+
 func TestSplitDiffToolCommand(t *testing.T) {
 	tests := []struct {
 		name     string
 		command  string
 		expected []string
+		wantErr  bool
 	}{
 		{
 			name:     "empty",
@@ -49,11 +136,32 @@ func TestSplitDiffToolCommand(t *testing.T) {
 			command:  `git --no-pager diff --src-prefix="a b/"`,
 			expected: []string{"git", "--no-pager", "diff", "--src-prefix=a b/"},
 		},
+		{
+			name:     "empty quotes keep an empty argument",
+			command:  `tool "" arg`,
+			expected: []string{"tool", "", "arg"},
+		},
+		{
+			name:    "unclosed double quote",
+			command: `diff -u "foo`,
+			wantErr: true,
+		},
+		{
+			name:    "unclosed single quote",
+			command: `diff -u 'foo`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, splitDiffToolCommand(tt.command))
+			args, err := splitDiffToolCommand(tt.command)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, args)
 		})
 	}
 }
@@ -81,7 +189,7 @@ func TestWriteDiffToolSides(t *testing.T) {
 			{
 				Key:        "default, nginx, Deployment (apps)",
 				Kind:       "Deployment",
-				ChangeType: "MODIFY",
+				ChangeType: changeTypeModify,
 				Diffs: []difflib.DiffRecord{
 					{Payload: "kind: Deployment", Delta: difflib.Common},
 					{Payload: "  replicas: 2", Delta: difflib.LeftOnly},
@@ -101,8 +209,8 @@ func TestWriteDiffToolSides(t *testing.T) {
 	newContent, err := os.ReadFile(newPath)
 	require.NoError(t, err)
 
-	require.Equal(t, "---\n# Source: default, nginx, Deployment (apps)\nkind: Deployment\n  replicas: 2\n", string(oldContent))
-	require.Equal(t, "---\n# Source: default, nginx, Deployment (apps)\nkind: Deployment\n  replicas: 3\n", string(newContent))
+	require.Equal(t, "---\n# Resource: default, nginx, Deployment (apps)\n# Change: MODIFY\nkind: Deployment\n  replicas: 2\n", string(oldContent))
+	require.Equal(t, "---\n# Resource: default, nginx, Deployment (apps)\n# Change: MODIFY\nkind: Deployment\n  replicas: 3\n", string(newContent))
 }
 
 func TestWriteDiffToolSidesSuppressedKind(t *testing.T) {
@@ -112,7 +220,7 @@ func TestWriteDiffToolSidesSuppressedKind(t *testing.T) {
 				Key:             "default, mysecret, Secret (v1)",
 				Kind:            "Secret",
 				SuppressedKinds: []string{"Secret"},
-				ChangeType:      "MODIFY",
+				ChangeType:      changeTypeModify,
 				Diffs: []difflib.DiffRecord{
 					{Payload: "kind: Secret", Delta: difflib.Common},
 					{Payload: "  password: aGkK", Delta: difflib.LeftOnly},
@@ -138,18 +246,49 @@ func TestWriteDiffToolSidesSuppressedKind(t *testing.T) {
 	require.Equal(t, string(oldContent), string(newContent), "suppressed entries must be identical on both sides")
 }
 
-func TestPrintDiffToolReport(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on a POSIX diff implementation")
+func TestWriteDiffToolSidesSuppressedLines(t *testing.T) {
+	report := &Report{
+		Entries: []ReportEntry{
+			// A MODIFY entry whose every changed line was filtered out by
+			// --suppress-output-line-regex (flipped to MODIFY_SUPPRESSED).
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: changeTypeModifySuppressed,
+			},
+			// An ADD entry can end up with empty diffs the same way.
+			{
+				Key:        "default, api, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: changeTypeAdd,
+			},
+		},
 	}
 
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old")
+	newPath := filepath.Join(dir, "new")
+	require.NoError(t, writeDiffToolSides(report, oldPath, newPath))
+
+	oldContent, err := os.ReadFile(oldPath)
+	require.NoError(t, err)
+	newContent, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+
+	require.Equal(t, string(oldContent), string(newContent),
+		"fully suppressed entries must be identical on both sides so the tool reports no change")
+	require.Equal(t, 2, strings.Count(string(oldContent), "# Changes suppressed by --suppress-output-line-regex"),
+		"each fully suppressed entry carries the placeholder")
+}
+
+func TestPrintDiffToolReport(t *testing.T) {
 	report := &Report{
-		diffToolCommand: "diff -u -N",
+		diffToolCommand: diffToolHelperCommand(t, "cat"),
 		Entries: []ReportEntry{
 			{
 				Key:        "default, nginx, Deployment (apps)",
 				Kind:       "Deployment",
-				ChangeType: "MODIFY",
+				ChangeType: changeTypeModify,
 				Diffs: []difflib.DiffRecord{
 					{Payload: "kind: Deployment", Delta: difflib.Common},
 					{Payload: "  replicas: 2", Delta: difflib.LeftOnly},
@@ -163,16 +302,13 @@ func TestPrintDiffToolReport(t *testing.T) {
 	printDiffToolReport(report, &buf)
 
 	output := buf.String()
-	require.Contains(t, output, "-  replicas: 2")
-	require.Contains(t, output, "+  replicas: 3")
+	require.Contains(t, output, "  replicas: 2")
+	require.Contains(t, output, "  replicas: 3")
+	require.Contains(t, output, "# Change: MODIFY", "change types must be visible to the tool user")
 }
 
 func TestPrintDiffToolReportEmpty(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on a POSIX diff implementation")
-	}
-
-	report := &Report{diffToolCommand: "diff -u -N", Entries: []ReportEntry{}}
+	report := &Report{diffToolCommand: diffToolHelperCommand(t, "args"), Entries: []ReportEntry{}}
 
 	var buf bytes.Buffer
 	printDiffToolReport(report, &buf)
@@ -181,17 +317,13 @@ func TestPrintDiffToolReportEmpty(t *testing.T) {
 }
 
 func TestPrintDiffToolReportPassesBothFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on a POSIX shell")
-	}
-
 	report := &Report{
-		diffToolCommand: "echo",
+		diffToolCommand: diffToolHelperCommand(t, "args"),
 		Entries: []ReportEntry{
 			{
 				Key:        "default, nginx, Deployment (apps)",
 				Kind:       "Deployment",
-				ChangeType: "MODIFY",
+				ChangeType: changeTypeModify,
 				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
 			},
 		},
@@ -200,15 +332,77 @@ func TestPrintDiffToolReportPassesBothFiles(t *testing.T) {
 	var buf bytes.Buffer
 	printDiffToolReport(report, &buf)
 
-	fields := bytes.Fields(buf.Bytes())
-	require.Len(t, fields, 2, "the external command must receive exactly the two file paths")
-	require.NotEqual(t, string(fields[0]), string(fields[1]), "both sides must be distinct files")
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2, "the external command must receive exactly the two file paths")
+	require.NotEqual(t, lines[0], lines[1], "both sides must be distinct files")
+	require.Equal(t, "old.yaml", filepath.Base(lines[0]))
+	require.Equal(t, "new.yaml", filepath.Base(lines[1]))
+}
+
+func TestPrintDiffToolReportExitCodeOneIsNotAnError(t *testing.T) {
+	report := &Report{
+		diffToolCommand: diffToolHelperCommand(t, "diff"),
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: changeTypeModify,
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	stderr := captureStderr(t, func() { printDiffToolReport(report, &buf) })
+
+	require.Contains(t, buf.String(), "helper: differences found", "tool output on stdout is preserved")
+	require.NotContains(t, stderr, "Error:", "exit code 1 means differences found and is not a failure")
+}
+
+func TestPrintDiffToolReportCommandFailure(t *testing.T) {
+	report := &Report{
+		diffToolCommand: diffToolHelperCommand(t, "fail"),
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: changeTypeModify,
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	stderr := captureStderr(t, func() { printDiffToolReport(report, &buf) })
+
+	require.Contains(t, stderr, "helper: boom", "the tool's own stderr is passed through")
+	require.Contains(t, stderr, "Error: diff tool", "the failure is reported")
+	require.Contains(t, stderr, "failed")
+	require.Empty(t, buf.String(), "a failed tool produces no report output")
+	require.NotPanics(t, func() {})
+}
+
+func TestPrintDiffToolReportUnclosedQuote(t *testing.T) {
+	report := &Report{
+		diffToolCommand: `diff -u "foo`,
+		Entries: []ReportEntry{
+			{
+				Key:        "default, nginx, Deployment (apps)",
+				Kind:       "Deployment",
+				ChangeType: changeTypeModify,
+				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	stderr := captureStderr(t, func() { printDiffToolReport(report, &buf) })
+
+	require.Contains(t, stderr, "unclosed", "an unclosed quote must not be silently dropped")
+	require.Empty(t, buf.String())
 }
 
 func TestManifestsDiffToolOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on a POSIX diff implementation")
-	}
 	t.Setenv(DiffToolEnvVar, "")
 
 	old := map[string]*manifest.MappingResult{
@@ -228,30 +422,32 @@ func TestManifestsDiffToolOutput(t *testing.T) {
 
 	t.Run("the command alone selects the external tool", func(t *testing.T) {
 		var buf bytes.Buffer
-		opts := &Options{OutputFormat: "diff", DiffToolCommand: "diff -u -N"}
+		opts := &Options{OutputFormat: outputFormatDiff, DiffToolCommand: diffToolHelperCommand(t, "cat")}
 
 		require.True(t, Manifests(old, updated, opts, &buf))
-		require.Contains(t, buf.String(), "-  replicas: 2")
-		require.Contains(t, buf.String(), "+  replicas: 3")
-		require.Contains(t, buf.String(), "@@", "expected unified diff output from the external tool")
+		require.Contains(t, buf.String(), "  replicas: 2")
+		require.Contains(t, buf.String(), "  replicas: 3")
+		require.Contains(t, buf.String(), "# Change: MODIFY", "expected output from the external tool")
+		require.NotContains(t, buf.String(), "has changed:", "the built-in renderer must not run")
 	})
 
 	t.Run("the environment variable alone selects the external tool", func(t *testing.T) {
-		t.Setenv(DiffToolEnvVar, "diff -u -N")
+		t.Setenv(DiffToolEnvVar, diffToolHelperCommand(t, "cat"))
 		var buf bytes.Buffer
-		opts := &Options{OutputFormat: "diff"}
+		opts := &Options{OutputFormat: outputFormatDiff}
 
 		require.True(t, Manifests(old, updated, opts, &buf))
-		require.Contains(t, buf.String(), "@@")
+		require.Contains(t, buf.String(), "# Change: MODIFY")
 	})
 
 	t.Run("the external tool wins over every built-in output", func(t *testing.T) {
+		helper := diffToolHelperCommand(t, "cat")
 		for _, format := range []string{"diff", "simple", "json", "template", "structured", "dyff"} {
 			var buf bytes.Buffer
-			opts := &Options{OutputFormat: format, DiffToolCommand: "diff -u -N"}
+			opts := &Options{OutputFormat: format, DiffToolCommand: helper}
 
 			require.True(t, Manifests(old, updated, opts, &buf))
-			require.Contains(t, buf.String(), "@@",
+			require.Contains(t, buf.String(), "# Change: MODIFY",
 				"output %q must be overridden by the external diff command", format)
 		}
 	})
@@ -262,23 +458,79 @@ func TestManifestsDiffToolOutput(t *testing.T) {
 
 		require.True(t, Manifests(old, updated, opts, &buf))
 		require.Contains(t, buf.String(), "to be changed.")
-		require.NotContains(t, buf.String(), "@@")
+		require.NotContains(t, buf.String(), "# Change: MODIFY")
 	})
 
 	t.Run("honors suppress-output-line-regex", func(t *testing.T) {
 		var buf bytes.Buffer
 		opts := &Options{
-			DiffToolCommand:           "diff -u -N",
+			DiffToolCommand:           diffToolHelperCommand(t, "cat"),
 			SuppressedOutputLineRegex: []string{"replicas"},
 		}
 
-		Manifests(old, updated, opts, &buf)
+		require.True(t, Manifests(old, updated, opts, &buf))
 		require.NotContains(t, buf.String(), "replicas")
+		require.Contains(t, buf.String(), "# Changes suppressed by --suppress-output-line-regex",
+			"fully suppressed entries must leave a trace instead of vanishing")
+	})
+
+	t.Run("honors --suppress for secret kinds", func(t *testing.T) {
+		oldSecret := map[string]*manifest.MappingResult{
+			"default, mysecret, Secret (v1)": {
+				Name:    "default, mysecret, Secret (v1)",
+				Kind:    "Secret",
+				Content: "kind: Secret\ndata:\n  password: aGkK\n",
+			},
+		}
+		newSecret := map[string]*manifest.MappingResult{
+			"default, mysecret, Secret (v1)": {
+				Name:    "default, mysecret, Secret (v1)",
+				Kind:    "Secret",
+				Content: "kind: Secret\ndata:\n  password: Ynll\n",
+			},
+		}
+
+		var buf bytes.Buffer
+		opts := &Options{
+			DiffToolCommand: diffToolHelperCommand(t, "cat"),
+			SuppressedKinds: []string{"Secret"},
+		}
+
+		require.True(t, Manifests(oldSecret, newSecret, opts, &buf))
+		require.Contains(t, buf.String(), "Changes suppressed on sensitive content of type Secret")
+		require.NotContains(t, buf.String(), "aGkK")
+		require.NotContains(t, buf.String(), "Ynll")
+	})
+
+	t.Run("redacts secrets end to end", func(t *testing.T) {
+		oldSecret := map[string]*manifest.MappingResult{
+			"default, mysecret, Secret (v1)": {
+				Name:    "default, mysecret, Secret (v1)",
+				Kind:    "Secret",
+				Content: "kind: Secret\ndata:\n  password: aGkK\n",
+			},
+		}
+		newSecret := map[string]*manifest.MappingResult{
+			"default, mysecret, Secret (v1)": {
+				Name:    "default, mysecret, Secret (v1)",
+				Kind:    "Secret",
+				Content: "kind: Secret\ndata:\n  password: Ynll\n",
+			},
+		}
+
+		var buf bytes.Buffer
+		opts := &Options{DiffToolCommand: diffToolHelperCommand(t, "cat")}
+
+		require.True(t, Manifests(oldSecret, newSecret, opts, &buf))
+		require.Contains(t, buf.String(), "-------- # (3 bytes)", "redaction of the old value must reach the tool's files")
+		require.Contains(t, buf.String(), "++++++++ # (3 bytes)", "redaction of the new value must reach the tool's files")
+		require.NotContains(t, buf.String(), "aGkK")
+		require.NotContains(t, buf.String(), "Ynll")
 	})
 
 	t.Run("no output when there are no changes", func(t *testing.T) {
 		var buf bytes.Buffer
-		opts := &Options{DiffToolCommand: "diff -u -N"}
+		opts := &Options{DiffToolCommand: diffToolHelperCommand(t, "cat")}
 
 		require.False(t, Manifests(old, old, opts, &buf))
 		require.Empty(t, buf.String())
@@ -288,7 +540,7 @@ func TestManifestsDiffToolOutput(t *testing.T) {
 func TestDiffToolEnabled(t *testing.T) {
 	t.Run("disabled when nothing is configured", func(t *testing.T) {
 		t.Setenv(DiffToolEnvVar, "")
-		require.False(t, (&Options{OutputFormat: "diff"}).DiffTool())
+		require.False(t, (&Options{OutputFormat: outputFormatDiff}).DiffTool())
 	})
 
 	t.Run("enabled by the command", func(t *testing.T) {
@@ -304,6 +556,15 @@ func TestDiffToolEnabled(t *testing.T) {
 	t.Run("a blank command does not enable it", func(t *testing.T) {
 		t.Setenv(DiffToolEnvVar, "   ")
 		require.False(t, (&Options{DiffToolCommand: "  "}).DiffTool())
+	})
+
+	t.Run("the environment variable can be ignored in favor of an explicit flag", func(t *testing.T) {
+		t.Setenv(DiffToolEnvVar, "difft")
+		opts := &Options{}
+		require.True(t, opts.DiffTool())
+
+		opts.IgnoreDiffToolEnvVar()
+		require.False(t, opts.DiffTool(), "an explicit flag must win over the environment")
 	})
 
 	t.Run("structured output is disabled while an external tool is used", func(t *testing.T) {
@@ -323,7 +584,7 @@ func TestPrintDiffToolReportNoCommand(t *testing.T) {
 			{
 				Key:        "default, nginx, Deployment (apps)",
 				Kind:       "Deployment",
-				ChangeType: "MODIFY",
+				ChangeType: changeTypeModify,
 				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
 			},
 		},
@@ -332,25 +593,4 @@ func TestPrintDiffToolReportNoCommand(t *testing.T) {
 	var buf bytes.Buffer
 	require.NotPanics(t, func() { printDiffToolReport(report, &buf) })
 	require.Empty(t, buf.String(), "without a command there is nothing to render")
-}
-
-func TestPrintDiffToolReportCommandFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on a POSIX shell")
-	}
-
-	report := &Report{
-		diffToolCommand: "helm-diff-no-such-external-tool",
-		Entries: []ReportEntry{
-			{
-				Key:        "default, nginx, Deployment (apps)",
-				Kind:       "Deployment",
-				ChangeType: "MODIFY",
-				Diffs:      []difflib.DiffRecord{{Payload: "kind: Deployment", Delta: difflib.Common}},
-			},
-		},
-	}
-
-	var buf bytes.Buffer
-	require.NotPanics(t, func() { printDiffToolReport(report, &buf) })
 }

--- a/diff/difftool_test.go
+++ b/diff/difftool_test.go
@@ -379,7 +379,6 @@ func TestPrintDiffToolReportCommandFailure(t *testing.T) {
 	require.Contains(t, stderr, "Error: diff tool", "the failure is reported")
 	require.Contains(t, stderr, "failed")
 	require.Empty(t, buf.String(), "a failed tool produces no report output")
-	require.NotPanics(t, func() {})
 }
 
 func TestPrintDiffToolReportUnclosedQuote(t *testing.T) {

--- a/diff/difftool_test.go
+++ b/diff/difftool_test.go
@@ -33,7 +33,27 @@ func diffToolHelperCommand(t *testing.T, behavior string) string {
 	binary, err := os.Executable()
 	require.NoError(t, err)
 
-	return fmt.Sprintf("%q -test.run=^TestDiffToolHelperProcess$ --", binary)
+	// The path is quoted so that spaces survive the tokenizer, but forward
+	// slashes are used on purpose: %q escapes backslashes (Windows paths) while
+	// splitDiffToolCommand strips quotes without unescaping, which would hand
+	// the child process a corrupted path like C:\\Users\\.... Forward slashes
+	// need no escaping and are accepted by the OS on every platform.
+	return fmt.Sprintf("%q -test.run=^TestDiffToolHelperProcess$ --", filepath.ToSlash(binary))
+}
+
+// TestDiffToolHelperCommandRoundTrips guards the contract the helper command
+// relies on: the tokenizer must recover the exact executable path from the
+// quoted command line, on every platform the CI matrix runs on.
+func TestDiffToolHelperCommandRoundTrips(t *testing.T) {
+	command := diffToolHelperCommand(t, "cat")
+
+	args, err := splitDiffToolCommand(command)
+	require.NoError(t, err)
+
+	binary, err := os.Executable()
+	require.NoError(t, err)
+	require.Equal(t, filepath.ToSlash(binary), args[0],
+		"the helper executable path must survive the command tokenizer")
 }
 
 // TestDiffToolHelperProcess is not a real test. It is the implementation of the
@@ -449,6 +469,21 @@ func TestManifestsDiffToolOutput(t *testing.T) {
 			require.Contains(t, buf.String(), "# Change: MODIFY",
 				"output %q must be overridden by the external diff command", format)
 		}
+	})
+
+	t.Run("the resolved command is captured at report time", func(t *testing.T) {
+		// A Report may be printed long after it was generated; rendering must
+		// not re-read the process environment (see Report.diffToolCommand).
+		t.Setenv(DiffToolEnvVar, diffToolHelperCommand(t, "cat"))
+		report, err := ManifestReport(old, updated, &Options{})
+		require.NoError(t, err)
+
+		t.Setenv(DiffToolEnvVar, "")
+
+		var buf bytes.Buffer
+		report.print(&buf)
+		require.Contains(t, buf.String(), "# Change: MODIFY",
+			"the report carries the resolved command; printing is env-independent")
 	})
 
 	t.Run("built-in output is used when no command is configured", func(t *testing.T) {

--- a/diff/report.go
+++ b/diff/report.go
@@ -20,10 +20,11 @@ import (
 
 // Report to store report data and format
 type Report struct {
-	format      ReportFormat
-	Entries     []ReportEntry
-	mode        string
-	findRenames float32
+	format          ReportFormat
+	Entries         []ReportEntry
+	mode            string
+	findRenames     float32
+	diffToolCommand string
 }
 
 // ReportEntry to store changes between releases

--- a/diff/report.go
+++ b/diff/report.go
@@ -63,6 +63,8 @@ type ReportTemplateSpec struct {
 func (r *Report) setupReportFormat(format string) {
 	r.mode = format
 	switch format {
+	case outputFormatDiff:
+		setupDiffReport(r)
 	case outputFormatSimple:
 		setupSimpleReport(r)
 	case outputFormatTemplate:
@@ -74,6 +76,7 @@ func (r *Report) setupReportFormat(format string) {
 	case outputFormatDyff:
 		setupDyffReport(r)
 	default:
+		// Unknown formats fall back to the default output (pre-existing behavior).
 		setupDiffReport(r)
 	}
 }

--- a/diff/report.go
+++ b/diff/report.go
@@ -20,10 +20,14 @@ import (
 
 // Report to store report data and format
 type Report struct {
-	format          ReportFormat
-	Entries         []ReportEntry
-	mode            string
-	findRenames     float32
+	format      ReportFormat
+	Entries     []ReportEntry
+	mode        string
+	findRenames float32
+	// diffToolCommand is the external diff tool command, resolved once when
+	// the report is generated (Options.configuredDiffToolCommand); it is empty
+	// when the built-in renderers are in use. Printing never re-reads the
+	// process environment.
 	diffToolCommand string
 }
 

--- a/diff/report.go
+++ b/diff/report.go
@@ -63,15 +63,15 @@ type ReportTemplateSpec struct {
 func (r *Report) setupReportFormat(format string) {
 	r.mode = format
 	switch format {
-	case "simple":
+	case outputFormatSimple:
 		setupSimpleReport(r)
-	case "template":
+	case outputFormatTemplate:
 		setupTemplateReport(r)
-	case "json":
+	case outputFormatJSON:
 		setupJSONReport(r)
-	case "structured":
+	case outputFormatStructured:
 		setupStructuredReport(r)
-	case "dyff":
+	case outputFormatDyff:
 		setupDyffReport(r)
 	default:
 		setupDiffReport(r)
@@ -157,11 +157,11 @@ func (r *Report) clean() {
 func setupDiffReport(r *Report) {
 	r.format.output = printDiffReport
 	r.format.changestyles = make(map[string]ChangeStyle)
-	r.format.changestyles["ADD"] = ChangeStyle{color: "green", message: "has been added:"}
-	r.format.changestyles["REMOVE"] = ChangeStyle{color: "red", message: "has been removed:"}
-	r.format.changestyles["MODIFY"] = ChangeStyle{color: "yellow", message: "has changed:"}
-	r.format.changestyles["OWNERSHIP"] = ChangeStyle{color: "magenta", message: "changed ownership:"}
-	r.format.changestyles["MODIFY_SUPPRESSED"] = ChangeStyle{color: "blue+h", message: "has changed, but diff is empty after suppression."}
+	r.format.changestyles[changeTypeAdd] = ChangeStyle{color: "green", message: "has been added:"}
+	r.format.changestyles[changeTypeRemove] = ChangeStyle{color: "red", message: "has been removed:"}
+	r.format.changestyles[changeTypeModify] = ChangeStyle{color: "yellow", message: "has changed:"}
+	r.format.changestyles[changeTypeOwnership] = ChangeStyle{color: "magenta", message: "changed ownership:"}
+	r.format.changestyles[changeTypeModifySuppressed] = ChangeStyle{color: "blue+h", message: "has changed, but diff is empty after suppression."}
 }
 
 // print report for default output: diff
@@ -181,21 +181,21 @@ func printDiffReport(r *Report, to io.Writer) {
 func setupSimpleReport(r *Report) {
 	r.format.output = printSimpleReport
 	r.format.changestyles = make(map[string]ChangeStyle)
-	r.format.changestyles["ADD"] = ChangeStyle{color: "green", message: "to be added."}
-	r.format.changestyles["REMOVE"] = ChangeStyle{color: "red", message: "to be removed."}
-	r.format.changestyles["MODIFY"] = ChangeStyle{color: "yellow", message: "to be changed."}
-	r.format.changestyles["OWNERSHIP"] = ChangeStyle{color: "magenta", message: "to change ownership."}
-	r.format.changestyles["MODIFY_SUPPRESSED"] = ChangeStyle{color: "blue+h", message: "has changed, but diff is empty after suppression."}
+	r.format.changestyles[changeTypeAdd] = ChangeStyle{color: "green", message: "to be added."}
+	r.format.changestyles[changeTypeRemove] = ChangeStyle{color: "red", message: "to be removed."}
+	r.format.changestyles[changeTypeModify] = ChangeStyle{color: "yellow", message: "to be changed."}
+	r.format.changestyles[changeTypeOwnership] = ChangeStyle{color: "magenta", message: "to change ownership."}
+	r.format.changestyles[changeTypeModifySuppressed] = ChangeStyle{color: "blue+h", message: "has changed, but diff is empty after suppression."}
 }
 
 // print report for simple output
 func printSimpleReport(r *Report, to io.Writer) {
 	summary := map[string]int{
-		"ADD":               0,
-		"REMOVE":            0,
-		"MODIFY":            0,
-		"OWNERSHIP":         0,
-		"MODIFY_SUPPRESSED": 0,
+		changeTypeAdd:              0,
+		changeTypeRemove:           0,
+		changeTypeModify:           0,
+		changeTypeOwnership:        0,
+		changeTypeModifySuppressed: 0,
 	}
 	for _, entry := range r.Entries {
 		_, _ = fmt.Fprintf(to, ansi.Color("%s %s", r.format.changestyles[entry.ChangeType].color)+"\n",
@@ -204,7 +204,7 @@ func printSimpleReport(r *Report, to io.Writer) {
 		)
 		summary[entry.ChangeType]++
 	}
-	_, _ = fmt.Fprintf(to, "Plan: %d to add, %d to change, %d to destroy, %d to change ownership.\n", summary["ADD"], summary["MODIFY"], summary["REMOVE"], summary["OWNERSHIP"])
+	_, _ = fmt.Fprintf(to, "Plan: %d to add, %d to change, %d to destroy, %d to change ownership.\n", summary[changeTypeAdd], summary[changeTypeModify], summary[changeTypeRemove], summary[changeTypeOwnership])
 }
 
 func newTemplate(name string) *template.Template {
@@ -227,11 +227,11 @@ func setupJSONReport(r *Report) {
 
 	r.format.output = templateReportPrinter(t)
 	r.format.changestyles = make(map[string]ChangeStyle)
-	r.format.changestyles["ADD"] = ChangeStyle{color: "green", message: ""}
-	r.format.changestyles["REMOVE"] = ChangeStyle{color: "red", message: ""}
-	r.format.changestyles["MODIFY"] = ChangeStyle{color: "yellow", message: ""}
-	r.format.changestyles["OWNERSHIP"] = ChangeStyle{color: "magenta", message: ""}
-	r.format.changestyles["MODIFY_SUPPRESSED"] = ChangeStyle{color: "blue+h", message: ""}
+	r.format.changestyles[changeTypeAdd] = ChangeStyle{color: "green", message: ""}
+	r.format.changestyles[changeTypeRemove] = ChangeStyle{color: "red", message: ""}
+	r.format.changestyles[changeTypeModify] = ChangeStyle{color: "yellow", message: ""}
+	r.format.changestyles[changeTypeOwnership] = ChangeStyle{color: "magenta", message: ""}
+	r.format.changestyles[changeTypeModifySuppressed] = ChangeStyle{color: "blue+h", message: ""}
 }
 
 // setup report for template output
@@ -259,11 +259,11 @@ func setupTemplateReport(r *Report) {
 
 	r.format.output = templateReportPrinter(tpl)
 	r.format.changestyles = make(map[string]ChangeStyle)
-	r.format.changestyles["ADD"] = ChangeStyle{color: "green", message: ""}
-	r.format.changestyles["REMOVE"] = ChangeStyle{color: "red", message: ""}
-	r.format.changestyles["MODIFY"] = ChangeStyle{color: "yellow", message: ""}
-	r.format.changestyles["OWNERSHIP"] = ChangeStyle{color: "magenta", message: ""}
-	r.format.changestyles["MODIFY_SUPPRESSED"] = ChangeStyle{color: "blue+h", message: ""}
+	r.format.changestyles[changeTypeAdd] = ChangeStyle{color: "green", message: ""}
+	r.format.changestyles[changeTypeRemove] = ChangeStyle{color: "red", message: ""}
+	r.format.changestyles[changeTypeModify] = ChangeStyle{color: "yellow", message: ""}
+	r.format.changestyles[changeTypeOwnership] = ChangeStyle{color: "magenta", message: ""}
+	r.format.changestyles[changeTypeModifySuppressed] = ChangeStyle{color: "blue+h", message: ""}
 }
 
 func setupStructuredReport(r *Report) {

--- a/diff/structured.go
+++ b/diff/structured.go
@@ -69,7 +69,7 @@ func buildStructuredEntry(key, changeType, kind string, suppressedKinds []string
 		return entry, nil
 	}
 
-	if changeType == "MODIFY" && oldJSON != nil && newJSON != nil {
+	if changeType == changeTypeModify && oldJSON != nil && newJSON != nil {
 		changes, err := calculateFieldChanges(oldJSON, newJSON)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Add --diff-tool flag and HELM_DIFF_TOOL env var to render diffs with an external command.

Manifests are written to two temp files whose paths are appended as the last two arguments.

Secret redaction and line suppression stay in effect since manifests are reconstructed from the report entries.

Exit code 1 (differences found) is ignored; other failures report to stderr without aborting helm-diff.

The patch addresses https://github.com/databus23/helm-diff/issues/638
