### PR TITLE
chore: bump plugin version to 3.15.12

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: diff
 # Version is the version of Helm plus the number of official builds for this
 # plugin
-version: "3.15.11"
+version: "3.15.12"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Bumps the plugin version in `plugin.yaml` from 3.15.11 to 3.15.12 for the next release, which includes the `--storage-namespace` / `HELM_DIFF_STORAGE_NAMESPACE` support merged in #1056.

Follows the existing version bump convention (see #1042, #1024).
